### PR TITLE
SQLite Release 3.34.1 On 2021-01-20

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## SQLite Release 3.34.1 On 2021-01-20
+
+1. Fix a potential use-after-free bug when processing a a subquery with both a correlated WHERE clause and a "HAVING 0" clause and where the parent query is an aggregate.
+2. Fix documentation typos
+3. Fix minor problems in extensions.
+
 ## SQLite Release 3.34.0 On 2020-12-01
 
 1. Added the sqlite3_txn_state() interface for reporting on the current transaction state of the database connection.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2020/sqlite-amalgamation-3340000.zip
+Download: https://sqlite.org/2021/sqlite-amalgamation-3340100.zip
 
 ```
-Archive:  sqlite-amalgamation-3340000.zip
+Archive:  sqlite-amalgamation-3340100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2020-12-01 17:36 00000000  sqlite-amalgamation-3340000/
- 8182247  Defl:N  2110535  74% 2020-12-01 17:36 306dba5d  sqlite-amalgamation-3340000/sqlite3.c
-  654280  Defl:N   164969  75% 2020-12-01 17:36 4379e51c  sqlite-amalgamation-3340000/shell.c
-   35437  Defl:N     6200  83% 2020-12-01 17:36 dc7e353d  sqlite-amalgamation-3340000/sqlite3ext.h
-  583198  Defl:N   150876  74% 2020-12-01 17:36 47fa2545  sqlite-amalgamation-3340000/sqlite3.h
+       0  Stored        0   0% 2021-01-20 15:38 00000000  sqlite-amalgamation-3340100/
+ 8182289  Defl:N  2110555  74% 2021-01-20 15:38 6b5605c3  sqlite-amalgamation-3340100/sqlite3.c
+  654331  Defl:N   164978  75% 2021-01-20 15:38 efb64f8a  sqlite-amalgamation-3340100/shell.c
+   35437  Defl:N     6200  83% 2021-01-20 15:38 dc7e353d  sqlite-amalgamation-3340100/sqlite3ext.h
+  583202  Defl:N   150875  74% 2021-01-20 15:38 b11b0078  sqlite-amalgamation-3340100/sqlite3.h
 --------          -------  ---                            -------
- 9455162          2432580  74%                            5 files
+ 9455259          2432608  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -2014,9 +2014,11 @@ static void sha3QueryFunc(
     }
     nCol = sqlite3_column_count(pStmt);
     z = sqlite3_sql(pStmt);
-    n = (int)strlen(z);
-    hash_step_vformat(&cx,"S%d:",n);
-    SHA3Update(&cx,(unsigned char*)z,n);
+    if( z ){
+      n = (int)strlen(z);
+      hash_step_vformat(&cx,"S%d:",n);
+      SHA3Update(&cx,(unsigned char*)z,n);
+    }
 
     /* Compute a hash over the result of the query */
     while( SQLITE_ROW==sqlite3_step(pStmt) ){
@@ -9968,10 +9970,12 @@ static int idxPopulateStat1(sqlite3expert *p, char **pzErr){
   idxFinalize(&rc, pIndexXInfo);
   idxFinalize(&rc, pWrite);
 
-  for(i=0; i<pCtx->nSlot; i++){
-    sqlite3_free(pCtx->aSlot[i].z);
+  if( pCtx ){
+    for(i=0; i<pCtx->nSlot; i++){
+      sqlite3_free(pCtx->aSlot[i].z);
+    }
+    sqlite3_free(pCtx);
   }
-  sqlite3_free(pCtx);
 
   if( rc==SQLITE_OK ){
     rc = sqlite3_exec(p->dbm, "ANALYZE sqlite_schema", 0, 0, 0);

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.34.0"
-#define SQLITE_VERSION_NUMBER 3034000
-#define SQLITE_SOURCE_ID      "2020-12-01 16:14:00 a26b6597e3ae272231b96f9982c3bcc17ddec2f2b6eb4df06a224b91089fed5b"
+#define SQLITE_VERSION        "3.34.1"
+#define SQLITE_VERSION_NUMBER 3034001
+#define SQLITE_SOURCE_ID      "2021-01-20 14:10:07 10e20c0b43500cfb9bbc0eaa061c57514f715d87238f4d835880cd846b9ebd1f"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -3697,7 +3697,7 @@ SQLITE_API sqlite3_file *sqlite3_database_file_object(const char*);
 ** If the Y parameter to sqlite3_free_filename(Y) is anything other
 ** than a NULL pointer or a pointer previously acquired from
 ** sqlite3_create_filename(), then bad things such as heap
-** corruption or segfaults may occur. The value Y should be
+** corruption or segfaults may occur. The value Y should not be
 ** used again after sqlite3_free_filename(Y) has been called.  This means
 ** that if the [sqlite3_vfs.xOpen()] method of a VFS has been called using Y,
 ** then the corresponding [sqlite3_module.xClose() method should also be


### PR DESCRIPTION
# SQLite Release 3.34.1 On 2021-01-20

1. Fix a potential use-after-free bug when processing a a subquery with both a correlated WHERE clause and a "HAVING 0" clause and where the parent query is an aggregate.
2. Fix documentation typos
3. Fix minor problems in extensions.