### PR TITLE
Release/v3.35.4

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## SQLite Release 3.35.4 On 2021-04-02
+
+1. Fix a defect in the query planner optimization identified by item 8b above. Ticket de7db14784a08053.
+2. Fix a defect in the new RETURNING syntax. Ticket 132994c8b1063bfb.
+3. Fix the new RETURNING feature so that it raises an error if one of the terms in the RETURNING clause references a unknown table, instead of silently ignoring that error.
+4. Fix an assertion associated with aggregate function processing that was incorrectly triggered by the push-down optimization.
+
 ## SQLite Release 3.35.3 On 2021-03-26
 
 1. Enhance the OP_OpenDup opcode of the bytecode engine so that it works even if the cursor being duplicated itself came from OP_OpenDup. Fix for ticket bb8a9fd4a9b7fce5. This problem only came to light due to the recent MATERIALIZED hint enhancement.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2021/sqlite-amalgamation-3350300.zip
+Download: https://sqlite.org/2021/sqlite-amalgamation-3350400.zip
 
 ```
-Archive:  sqlite-amalgamation-3350300.zip
+Archive:  sqlite-amalgamation-3350400.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2021-03-26 15:24 00000000  sqlite-amalgamation-3350300/
- 8266903  Defl:N  2133223  74% 2021-03-26 15:24 4bb7e7b5  sqlite-amalgamation-3350300/sqlite3.c
-  661019  Defl:N   166992  75% 2021-03-26 15:24 cd8db3be  sqlite-amalgamation-3350300/shell.c
-   35437  Defl:N     6200  83% 2021-03-26 15:24 dc7e353d  sqlite-amalgamation-3350300/sqlite3ext.h
-  584223  Defl:N   151130  74% 2021-03-26 15:24 f2ff8f5c  sqlite-amalgamation-3350300/sqlite3.h
+       0  Stored        0   0% 2021-04-02 17:40 00000000  sqlite-amalgamation-3350400/
+ 8268240  Defl:N  2133592  74% 2021-04-02 17:40 81871ce8  sqlite-amalgamation-3350400/sqlite3.c
+  661019  Defl:N   166992  75% 2021-04-02 17:40 cd8db3be  sqlite-amalgamation-3350400/shell.c
+   35437  Defl:N     6200  83% 2021-04-02 17:40 dc7e353d  sqlite-amalgamation-3350400/sqlite3ext.h
+  584223  Defl:N   151134  74% 2021-04-02 17:40 cd055d81  sqlite-amalgamation-3350400/sqlite3.h
 --------          -------  ---                            -------
- 9547582          2457545  74%                            5 files
+ 9548919          2457918  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.35.3"
-#define SQLITE_VERSION_NUMBER 3035003
-#define SQLITE_SOURCE_ID      "2021-03-26 12:12:52 4c5e6c200adc8afe0814936c67a971efc516d1bd739cb620235592f18f40be2a"
+#define SQLITE_VERSION        "3.35.4"
+#define SQLITE_VERSION_NUMBER 3035004
+#define SQLITE_SOURCE_ID      "2021-04-02 15:20:15 5d4c65779dab868b285519b19e4cf9d451d50c6048f06f653aa701ec212df45e"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.35.4 On 2021-04-02

1. Fix a defect in the query planner optimization identified by item 8b above. Ticket de7db14784a08053.
2. Fix a defect in the new RETURNING syntax. Ticket 132994c8b1063bfb.
3. Fix the new RETURNING feature so that it raises an error if one of the terms in the RETURNING clause references a unknown table, instead of silently ignoring that error.
4. Fix an assertion associated with aggregate function processing that was incorrectly triggered by the push-down optimization.