### PR TITLE
Release/v3.35.5

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## SQLite Release 3.35.5 On 2021-04-19
+
+1. Fix defects in the new ALTER TABLE DROP COLUMN feature that could corrupt the database file.
+2. Fix an obscure query optimizer problem that might cause an incorrect query result.
+
 ## SQLite Release 3.35.4 On 2021-04-02
 
 1. Fix a defect in the query planner optimization identified by item 8b above. Ticket de7db14784a08053.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2021/sqlite-amalgamation-3350400.zip
+Download: https://sqlite.org/2021/sqlite-amalgamation-3350500.zip
 
 ```
-Archive:  sqlite-amalgamation-3350400.zip
+Archive:  sqlite-amalgamation-3350500.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2021-04-02 17:40 00000000  sqlite-amalgamation-3350400/
- 8268240  Defl:N  2133592  74% 2021-04-02 17:40 81871ce8  sqlite-amalgamation-3350400/sqlite3.c
-  661019  Defl:N   166992  75% 2021-04-02 17:40 cd8db3be  sqlite-amalgamation-3350400/shell.c
-   35437  Defl:N     6200  83% 2021-04-02 17:40 dc7e353d  sqlite-amalgamation-3350400/sqlite3ext.h
-  584223  Defl:N   151134  74% 2021-04-02 17:40 cd055d81  sqlite-amalgamation-3350400/sqlite3.h
+       0  Stored        0   0% 2021-04-19 20:56 00000000  sqlite-amalgamation-3350500/
+ 8268672  Defl:N  2133689  74% 2021-04-19 20:56 296dc69f  sqlite-amalgamation-3350500/sqlite3.c
+  661019  Defl:N   166992  75% 2021-04-19 20:56 cd8db3be  sqlite-amalgamation-3350500/shell.c
+   35437  Defl:N     6200  83% 2021-04-19 20:56 dc7e353d  sqlite-amalgamation-3350500/sqlite3ext.h
+  584223  Defl:N   151132  74% 2021-04-19 20:56 3fdec54c  sqlite-amalgamation-3350500/sqlite3.h
 --------          -------  ---                            -------
- 9548919          2457918  74%                            5 files
+ 9549351          2458013  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.35.4"
-#define SQLITE_VERSION_NUMBER 3035004
-#define SQLITE_SOURCE_ID      "2021-04-02 15:20:15 5d4c65779dab868b285519b19e4cf9d451d50c6048f06f653aa701ec212df45e"
+#define SQLITE_VERSION        "3.35.5"
+#define SQLITE_VERSION_NUMBER 3035005
+#define SQLITE_SOURCE_ID      "2021-04-19 18:32:05 1b256d97b553a9611efca188a3d995a2fff712759044ba480f9a0c9e98fae886"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.35.5 On 2021-04-19

1. Fix defects in the new ALTER TABLE DROP COLUMN feature that could corrupt the database file.
2. Fix an obscure query optimizer problem that might cause an incorrect query result.