### PR TITLE
Release/v3.37.2

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## SQLite Release 3.37.2 On 2022-01-06
+
+1. Fix a bug introduced in version 3.35.0 (2021-03-12) that can cause database corruption if a SAVEPOINT is rolled back while in PRAGMA temp_store=MEMORY mode, and other changes are made, and then the outer transaction commits. Check-in 73c2b50211d3ae26
+2. Fix a long-standing problem with ON DELETE CASCADE and ON UPDATE CASCADE in which a cache of the bytecode used to implement the cascading change was not being reset following a local DDL change. Check-in 5232c9777fe4fb13.
+3. Other minor fixes that should not impact production builds.
+
 ## SQLite Release 3.37.1 On 2021-12-30
 
 1. Fix a bug introduced by the UPSERT enhancements of version 3.35.0 that can cause incorrect byte-code to be generated for some obscure but valid SQL, possibly resulting in a NULL-pointer dereference.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2021/sqlite-amalgamation-3370100.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3370200.zip
 
 ```
-Archive:  sqlite-amalgamation-3370100.zip
+Archive:  sqlite-amalgamation-3370200.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2021-12-30 16:56 00000000  sqlite-amalgamation-3370100/
- 8386037  Defl:N  2161939  74% 2021-12-30 16:56 ce89f679  sqlite-amalgamation-3370100/sqlite3.c
-  704543  Defl:N   179009  75% 2021-12-30 16:56 4bd0779f  sqlite-amalgamation-3370100/shell.c
-   35995  Defl:N     6291  83% 2021-12-30 16:56 730b3fe2  sqlite-amalgamation-3370100/sqlite3ext.h
-  595850  Defl:N   154085  74% 2021-12-30 16:56 5c878549  sqlite-amalgamation-3370100/sqlite3.h
+       0  Stored        0   0% 2022-01-06 14:43 00000000  sqlite-amalgamation-3370200/
+ 8387177  Defl:N  2162323  74% 2022-01-06 14:43 1dbf91f4  sqlite-amalgamation-3370200/sqlite3.c
+  704543  Defl:N   179009  75% 2022-01-06 14:43 4bd0779f  sqlite-amalgamation-3370200/shell.c
+   35995  Defl:N     6291  83% 2022-01-06 14:43 730b3fe2  sqlite-amalgamation-3370200/sqlite3ext.h
+  595850  Defl:N   154083  74% 2022-01-06 14:43 f26d874a  sqlite-amalgamation-3370200/sqlite3.h
 --------          -------  ---                            -------
- 9722425          2501324  74%                            5 files
+ 9723565          2501706  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.37.1"
-#define SQLITE_VERSION_NUMBER 3037001
-#define SQLITE_SOURCE_ID      "2021-12-30 15:30:28 378629bf2ea546f73eee84063c5358439a12f7300e433f18c9e1bddd948dea62"
+#define SQLITE_VERSION        "3.37.2"
+#define SQLITE_VERSION_NUMBER 3037002
+#define SQLITE_SOURCE_ID      "2022-01-06 13:25:41 872ba256cbf61d9290b571c0e6d82a20c224ca3ad82971edc46b29818d5d17a0"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.37.2 On 2022-01-06

1. Fix a bug introduced in version 3.35.0 (2021-03-12) that can cause database corruption if a SAVEPOINT is rolled back while in PRAGMA temp_store=MEMORY mode, and other changes are made, and then the outer transaction commits. Check-in 73c2b50211d3ae26
2. Fix a long-standing problem with ON DELETE CASCADE and ON UPDATE CASCADE in which a cache of the bytecode used to implement the cascading change was not being reset following a local DDL change. Check-in 5232c9777fe4fb13.
3. Other minor fixes that should not impact production builds.