### PR TITLE
Release/v3.38.1

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## SQLite Release 3.38.1 On 2022-03-12
+
+1. Fix problems with the new Bloom filter optimization that might cause some obscure queries to get an incorrect answer.
+2. Fix the localtime modifier of the date and time functions so that it preserves fractional seconds.
+3. Fix the sqlite_offset SQL function so that it works correctly even in corner cases such as when the argument is a virtual column or the column of a view.
+4. Fix row value IN operator constraints on virtual tables so that they work correctly even if the virtual table implementation relies on bytecode to filter rows that do not satisfy the constraint.
+5. Other minor fixes to assert() statements, test cases, and documentation. See the source code timeline for details.
+
 ## SQLite Release 3.38.0 On 2022-02-22
 
 1. Added the -> and ->> operators for easier processing of JSON. The new operators are compatible with MySQL and PostgreSQL.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3380000.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3380100.zip
 
 ```
-Archive:  sqlite-amalgamation-3380000.zip
+Archive:  sqlite-amalgamation-3380100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-02-22 20:18 00000000  sqlite-amalgamation-3380000/
- 8457709  Defl:N  2181754  74% 2022-02-22 20:18 20e64d90  sqlite-amalgamation-3380000/sqlite3.c
-  724661  Defl:N   184966  75% 2022-02-22 20:18 302aaab4  sqlite-amalgamation-3380000/shell.c
-   36750  Defl:N     6408  83% 2022-02-22 20:18 11790a34  sqlite-amalgamation-3380000/sqlite3ext.h
-  611623  Defl:N   158363  74% 2022-02-22 20:18 4aa2e440  sqlite-amalgamation-3380000/sqlite3.h
+       0  Stored        0   0% 2022-03-12 15:04 00000000  sqlite-amalgamation-3380100/
+ 8460268  Defl:N  2182569  74% 2022-03-12 15:04 93b3a08d  sqlite-amalgamation-3380100/sqlite3.c
+  724857  Defl:N   185067  75% 2022-03-12 15:04 9d498e7a  sqlite-amalgamation-3380100/shell.c
+   36750  Defl:N     6408  83% 2022-03-12 15:04 11790a34  sqlite-amalgamation-3380100/sqlite3ext.h
+  611797  Defl:N   158393  74% 2022-03-12 15:04 aec2a486  sqlite-amalgamation-3380100/sqlite3.h
 --------          -------  ---                            -------
- 9830743          2531491  74%                            5 files
+ 9833672          2532437  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -19906,7 +19906,7 @@ static int do_meta_command(char *zLine, ShellState *p){
 
   if( c=='i' && strncmp(azArg[0], "import", n)==0 ){
     char *zTable = 0;           /* Insert data into this table */
-    char *zSchema = "main";     /* within this schema */
+    char *zSchema = 0;          /* within this schema (may default to "main") */
     char *zFile = 0;            /* Name of file to extra content from */
     sqlite3_stmt *pStmt = NULL; /* A statement */
     int nCol;                   /* Number of columns in the table */
@@ -19915,11 +19915,13 @@ static int do_meta_command(char *zLine, ShellState *p){
     int needCommit;             /* True to COMMIT or ROLLBACK at end */
     int nSep;                   /* Number of bytes in p->colSeparator[] */
     char *zSql;                 /* An SQL statement */
+    char *zFullTabName;         /* Table name with schema if applicable */
     ImportCtx sCtx;             /* Reader context */
     char *(SQLITE_CDECL *xRead)(ImportCtx*); /* Func to read one value */
     int eVerbose = 0;           /* Larger for more console output */
     int nSkip = 0;              /* Initial lines to skip */
     int useOutputMode = 1;      /* Use output mode to determine separators */
+    char *zCreate = 0;          /* CREATE TABLE statement text */
 
     failIfSafeMode(p, "cannot run .import in safe mode");
     memset(&sCtx, 0, sizeof(sCtx));
@@ -20042,7 +20044,6 @@ static int do_meta_command(char *zLine, ShellState *p){
       import_cleanup(&sCtx);
       goto meta_command_exit;
     }
-    /* Below, resources must be freed before exit. */
     if( eVerbose>=2 || (eVerbose>=1 && useOutputMode) ){
       char zSep[2];
       zSep[1] = 0;
@@ -20054,11 +20055,17 @@ static int do_meta_command(char *zLine, ShellState *p){
       output_c_string(p->out, zSep);
       utf8_printf(p->out, "\n");
     }
+    /* Below, resources must be freed before exit. */
     while( (nSkip--)>0 ){
       while( xRead(&sCtx) && sCtx.cTerm==sCtx.cColSep ){}
     }
-    zSql = sqlite3_mprintf("SELECT * FROM \"%w\".\"%w\"", zSchema, zTable);
-    if( zSql==0 ){
+    if( zSchema!=0 ){
+      zFullTabName = sqlite3_mprintf("\"%w\".\"%w\"", zSchema, zTable);
+    }else{
+      zFullTabName = sqlite3_mprintf("\"%w\"", zTable);
+    }
+    zSql = sqlite3_mprintf("SELECT * FROM %s", zFullTabName);
+    if( zSql==0 || zFullTabName==0 ){
       import_cleanup(&sCtx);
       shell_out_of_memory();
     }
@@ -20066,11 +20073,10 @@ static int do_meta_command(char *zLine, ShellState *p){
     rc = sqlite3_prepare_v2(p->db, zSql, -1, &pStmt, 0);
     import_append_char(&sCtx, 0);    /* To ensure sCtx.z is allocated */
     if( rc && sqlite3_strglob("no such table: *", sqlite3_errmsg(p->db))==0 ){
-      char *zCreate = sqlite3_mprintf("CREATE TABLE \"%w\".\"%w\"",
-                                      zSchema, zTable);
       sqlite3 *dbCols = 0;
       char *zRenames = 0;
       char *zColDefs;
+      zCreate = sqlite3_mprintf("CREATE TABLE %s", zFullTabName);
       while( xRead(&sCtx) ){
         zAutoColumn(sCtx.z, &dbCols, 0);
         if( sCtx.cTerm!=sCtx.cColSep ) break;
@@ -20084,9 +20090,12 @@ static int do_meta_command(char *zLine, ShellState *p){
       }
       assert(dbCols==0);
       if( zColDefs==0 ){
-        sqlite3_free(zCreate);
-        import_cleanup(&sCtx);
         utf8_printf(stderr,"%s: empty file\n", sCtx.zFile);
+      import_fail:
+        sqlite3_free(zCreate);
+        sqlite3_free(zSql);
+        sqlite3_free(zFullTabName);
+        import_cleanup(&sCtx);
         rc = 1;
         goto meta_command_exit;
       }
@@ -20097,22 +20106,18 @@ static int do_meta_command(char *zLine, ShellState *p){
       rc = sqlite3_exec(p->db, zCreate, 0, 0, 0);
       if( rc ){
         utf8_printf(stderr, "%s failed:\n%s\n", zCreate, sqlite3_errmsg(p->db));
-        sqlite3_free(zCreate);
-        import_cleanup(&sCtx);
-        rc = 1;
-        goto meta_command_exit;
+        goto import_fail;
       }
       sqlite3_free(zCreate);
+      zCreate = 0;
       rc = sqlite3_prepare_v2(p->db, zSql, -1, &pStmt, 0);
     }
-    sqlite3_free(zSql);
     if( rc ){
       if (pStmt) sqlite3_finalize(pStmt);
       utf8_printf(stderr,"Error: %s\n", sqlite3_errmsg(p->db));
-      import_cleanup(&sCtx);
-      rc = 1;
-      goto meta_command_exit;
+      goto import_fail;
     }
+    sqlite3_free(zSql);
     nCol = sqlite3_column_count(pStmt);
     sqlite3_finalize(pStmt);
     pStmt = 0;
@@ -20122,8 +20127,7 @@ static int do_meta_command(char *zLine, ShellState *p){
       import_cleanup(&sCtx);
       shell_out_of_memory();
     }
-    sqlite3_snprintf(nByte+20, zSql, "INSERT INTO \"%w\".\"%w\" VALUES(?",
-                     zSchema, zTable);
+    sqlite3_snprintf(nByte+20, zSql, "INSERT INTO %s VALUES(?", zFullTabName);
     j = strlen30(zSql);
     for(i=1; i<nCol; i++){
       zSql[j++] = ',';
@@ -20135,14 +20139,13 @@ static int do_meta_command(char *zLine, ShellState *p){
       utf8_printf(p->out, "Insert using: %s\n", zSql);
     }
     rc = sqlite3_prepare_v2(p->db, zSql, -1, &pStmt, 0);
-    sqlite3_free(zSql);
     if( rc ){
       utf8_printf(stderr, "Error: %s\n", sqlite3_errmsg(p->db));
       if (pStmt) sqlite3_finalize(pStmt);
-      import_cleanup(&sCtx);
-      rc = 1;
-      goto meta_command_exit;
+      goto import_fail;
     }
+    sqlite3_free(zSql);
+    sqlite3_free(zFullTabName);
     needCommit = sqlite3_get_autocommit(p->db);
     if( needCommit ) sqlite3_exec(p->db, "BEGIN", 0, 0, 0);
     do{

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.38.0"
-#define SQLITE_VERSION_NUMBER 3038000
-#define SQLITE_SOURCE_ID      "2022-02-22 18:58:40 40fa792d359f84c3b9e9d6623743e1a59826274e221df1bde8f47086968a1bab"
+#define SQLITE_VERSION        "3.38.1"
+#define SQLITE_VERSION_NUMBER 3038001
+#define SQLITE_SOURCE_ID      "2022-03-12 13:37:29 38c210fdd258658321c85ec9c01a072fda3ada94540e3239d29b34dc547a8cbc"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -4979,6 +4979,10 @@ SQLITE_API int sqlite3_data_count(sqlite3_stmt *pStmt);
 ** even empty strings, are always zero-terminated.  ^The return
 ** value from sqlite3_column_blob() for a zero-length BLOB is a NULL pointer.
 **
+** ^Strings returned by sqlite3_column_text16() always have the endianness
+** which is native to the platform, regardless of the text encoding set
+** for the database.
+**
 ** <b>Warning:</b> ^The object returned by [sqlite3_column_value()] is an
 ** [unprotected sqlite3_value] object.  In a multithreaded environment,
 ** an unprotected sqlite3_value object may only be used safely with
@@ -4992,7 +4996,7 @@ SQLITE_API int sqlite3_data_count(sqlite3_stmt *pStmt);
 ** [application-defined SQL functions] or [virtual tables], not within
 ** top-level application code.
 **
-** The these routines may attempt to convert the datatype of the result.
+** These routines may attempt to convert the datatype of the result.
 ** ^For example, if the internal representation is FLOAT and a text result
 ** is requested, [sqlite3_snprintf()] is used internally to perform the
 ** conversion automatically.  ^(The following table details the conversions
@@ -5017,7 +5021,7 @@ SQLITE_API int sqlite3_data_count(sqlite3_stmt *pStmt);
 ** <tr><td>  TEXT    <td>   BLOB    <td> No change
 ** <tr><td>  BLOB    <td> INTEGER   <td> [CAST] to INTEGER
 ** <tr><td>  BLOB    <td>  FLOAT    <td> [CAST] to REAL
-** <tr><td>  BLOB    <td>   TEXT    <td> Add a zero terminator if needed
+** <tr><td>  BLOB    <td>   TEXT    <td> [CAST] to TEXT, ensure zero terminator
 ** </table>
 ** </blockquote>)^
 **
@@ -9767,7 +9771,7 @@ SQLITE_API int sqlite3_vtab_in_next(sqlite3_value *pVal, sqlite3_value **ppOut);
 ** ^When xBestIndex returns, the sqlite3_value object returned by
 ** sqlite3_vtab_rhs_value() is automatically deallocated.
 **
-** The "_rhs_" in the name of this routine is an appreviation for
+** The "_rhs_" in the name of this routine is an abbreviation for
 ** "Right-Hand Side".
 */
 SQLITE_API int sqlite3_vtab_rhs_value(sqlite3_index_info*, int, sqlite3_value **ppVal);


### PR DESCRIPTION
# SQLite Release 3.38.1 On 2022-03-12

1. Fix problems with the new Bloom filter optimization that might cause some obscure queries to get an incorrect answer.
2. Fix the localtime modifier of the date and time functions so that it preserves fractional seconds.
3. Fix the sqlite_offset SQL function so that it works correctly even in corner cases such as when the argument is a virtual column or the column of a view.
4. Fix row value IN operator constraints on virtual tables so that they work correctly even if the virtual table implementation relies on bytecode to filter rows that do not satisfy the constraint.
5. Other minor fixes to assert() statements, test cases, and documentation. See the source code timeline for details.