### PR TITLE
Release/v3.38.2

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## SQLite Release 3.38.2 On 2022-03-26
+
+1. Fix a user-discovered problem with the new Bloom filter optimization that might cause an incorrect answer when doing a LEFT JOIN with a WHERE clause constraint that says that one of the columns on the right table of the LEFT JOIN is NULL. See forum thread 031e262a89b6a9d2.
+2. Other minor patches. See the timeline for details.
+
 ## SQLite Release 3.38.1 On 2022-03-12
 
 1. Fix problems with the new Bloom filter optimization that might cause some obscure queries to get an incorrect answer.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3380100.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3380200.zip
 
 ```
-Archive:  sqlite-amalgamation-3380100.zip
+Archive:  sqlite-amalgamation-3380200.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-03-12 15:04 00000000  sqlite-amalgamation-3380100/
- 8460268  Defl:N  2182569  74% 2022-03-12 15:04 93b3a08d  sqlite-amalgamation-3380100/sqlite3.c
-  724857  Defl:N   185067  75% 2022-03-12 15:04 9d498e7a  sqlite-amalgamation-3380100/shell.c
-   36750  Defl:N     6408  83% 2022-03-12 15:04 11790a34  sqlite-amalgamation-3380100/sqlite3ext.h
-  611797  Defl:N   158393  74% 2022-03-12 15:04 aec2a486  sqlite-amalgamation-3380100/sqlite3.h
+       0  Stored        0   0% 2022-03-26 15:21 00000000  sqlite-amalgamation-3380200/
+ 8462111  Defl:N  2183015  74% 2022-03-26 15:21 d3c14082  sqlite-amalgamation-3380200/sqlite3.c
+  724963  Defl:N   185103  75% 2022-03-26 15:21 5c7cd07b  sqlite-amalgamation-3380200/shell.c
+   36750  Defl:N     6408  83% 2022-03-26 15:21 11790a34  sqlite-amalgamation-3380200/sqlite3ext.h
+  611797  Defl:N   158394  74% 2022-03-26 15:21 8d072a77  sqlite-amalgamation-3380200/sqlite3.h
 --------          -------  ---                            -------
- 9833672          2532437  74%                            5 files
+ 9835621          2532920  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -7964,9 +7964,14 @@ static int zipfileFilter(
     zipfileCursorErr(pCsr, "zipfile() function requires an argument");
     return SQLITE_ERROR;
   }else if( sqlite3_value_type(argv[0])==SQLITE_BLOB ){
+    static const u8 aEmptyBlob = 0;
     const u8 *aBlob = (const u8*)sqlite3_value_blob(argv[0]);
     int nBlob = sqlite3_value_bytes(argv[0]);
     assert( pTab->pFirstEntry==0 );
+    if( aBlob==0 ){
+      aBlob = &aEmptyBlob;
+      nBlob = 0;
+    }
     rc = zipfileLoadDirectory(pTab, aBlob, nBlob);
     pCsr->pFreeEntry = pTab->pFirstEntry;
     pTab->pFirstEntry = pTab->pLastEntry = 0;

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.38.1"
-#define SQLITE_VERSION_NUMBER 3038001
-#define SQLITE_SOURCE_ID      "2022-03-12 13:37:29 38c210fdd258658321c85ec9c01a072fda3ada94540e3239d29b34dc547a8cbc"
+#define SQLITE_VERSION        "3.38.2"
+#define SQLITE_VERSION_NUMBER 3038002
+#define SQLITE_SOURCE_ID      "2022-03-26 13:51:10 d33c709cc0af66bc5b6dc6216eba9f1f0b40960b9ae83694c986fbf4c1d6f08f"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.38.2 On 2022-03-26

1. Fix a user-discovered problem with the new Bloom filter optimization that might cause an incorrect answer when doing a LEFT JOIN with a WHERE clause constraint that says that one of the columns on the right table of the LEFT JOIN is NULL. See forum thread 031e262a89b6a9d2.
2. Other minor patches. See the timeline for details.