### PR TITLE
Release/v3.38.3

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## SQLite Release 3.38.3 On 2022-04-27
+
+1. Fix a case of the query planner be overly aggressive with optimizing automatic-index and Bloom-filter construction, using inappropriate ON clause terms to restrict the size of the automatic-index or Bloom filter, and resulting in missing rows in the output. Forum thread 0d3200f4f3bcd3a3.
+2. Other minor patches. See the timeline for details.
+
 ## SQLite Release 3.38.2 On 2022-03-26
 
 1. Fix a user-discovered problem with the new Bloom filter optimization that might cause an incorrect answer when doing a LEFT JOIN with a WHERE clause constraint that says that one of the columns on the right table of the LEFT JOIN is NULL. See forum thread 031e262a89b6a9d2.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3380200.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3380300.zip
 
 ```
-Archive:  sqlite-amalgamation-3380200.zip
+Archive:  sqlite-amalgamation-3380300.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-03-26 15:21 00000000  sqlite-amalgamation-3380200/
- 8462111  Defl:N  2183015  74% 2022-03-26 15:21 d3c14082  sqlite-amalgamation-3380200/sqlite3.c
-  724963  Defl:N   185103  75% 2022-03-26 15:21 5c7cd07b  sqlite-amalgamation-3380200/shell.c
-   36750  Defl:N     6408  83% 2022-03-26 15:21 11790a34  sqlite-amalgamation-3380200/sqlite3ext.h
-  611797  Defl:N   158394  74% 2022-03-26 15:21 8d072a77  sqlite-amalgamation-3380200/sqlite3.h
+       0  Stored        0   0% 2022-04-27 15:59 00000000  sqlite-amalgamation-3380300/
+ 8463917  Defl:N  2183581  74% 2022-04-27 15:59 9f12f31c  sqlite-amalgamation-3380300/sqlite3.c
+  725010  Defl:N   185132  75% 2022-04-27 15:59 bdfff0cd  sqlite-amalgamation-3380300/shell.c
+   36750  Defl:N     6408  83% 2022-04-27 15:59 11790a34  sqlite-amalgamation-3380300/sqlite3ext.h
+  611797  Defl:N   158394  74% 2022-04-27 15:59 6c9eb334  sqlite-amalgamation-3380300/sqlite3.h
 --------          -------  ---                            -------
- 9835621          2532920  74%                            5 files
+ 9837474          2533515  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -22644,7 +22644,8 @@ static int process_input(ShellState *p){
       qss = QSS_Start;
     }
   }
-  if( nSql && QSS_PLAINDARK(qss) ){
+  if( nSql ){
+    /* This may be incomplete. Let the SQL parser deal with that. */
     errCnt += runOneSqlLine(p, zSql, p->in, startline);
   }
   free(zSql);

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.38.2"
-#define SQLITE_VERSION_NUMBER 3038002
-#define SQLITE_SOURCE_ID      "2022-03-26 13:51:10 d33c709cc0af66bc5b6dc6216eba9f1f0b40960b9ae83694c986fbf4c1d6f08f"
+#define SQLITE_VERSION        "3.38.3"
+#define SQLITE_VERSION_NUMBER 3038003
+#define SQLITE_SOURCE_ID      "2022-04-27 12:03:15 9547e2c38a1c6f751a77d4d796894dec4dc5d8f5d79b1cd39e1ffc50df7b3be4"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.38.3 On 2022-04-27

1. Fix a case of the query planner be overly aggressive with optimizing automatic-index and Bloom-filter construction, using inappropriate ON clause terms to restrict the size of the automatic-index or Bloom filter, and resulting in missing rows in the output. Forum thread 0d3200f4f3bcd3a3.
2. Other minor patches. See the timeline for details.