### PR TITLE
Release/v3.38.4

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## SQLite Release 3.38.4 On 2022-05-04
+
+1. Fix a byte-code problem in the Bloom filter pull-down optimization added by release 3.38.0 in which an error in the byte code causes the byte code engine to enter an infinite loop when the pull-down optimization encounters a NULL key. Forum thread 2482b32700384a0f.
+2. Other minor patches. See the timeline for details.
+
 ## SQLite Release 3.38.3 On 2022-04-27
 
 1. Fix a case of the query planner be overly aggressive with optimizing automatic-index and Bloom-filter construction, using inappropriate ON clause terms to restrict the size of the automatic-index or Bloom filter, and resulting in missing rows in the output. Forum thread 0d3200f4f3bcd3a3.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3380300.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3380400.zip
 
 ```
-Archive:  sqlite-amalgamation-3380300.zip
+Archive:  sqlite-amalgamation-3380400.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-04-27 15:59 00000000  sqlite-amalgamation-3380300/
- 8463917  Defl:N  2183581  74% 2022-04-27 15:59 9f12f31c  sqlite-amalgamation-3380300/sqlite3.c
-  725010  Defl:N   185132  75% 2022-04-27 15:59 bdfff0cd  sqlite-amalgamation-3380300/shell.c
-   36750  Defl:N     6408  83% 2022-04-27 15:59 11790a34  sqlite-amalgamation-3380300/sqlite3ext.h
-  611797  Defl:N   158394  74% 2022-04-27 15:59 6c9eb334  sqlite-amalgamation-3380300/sqlite3.h
+       0  Stored        0   0% 2022-05-04 18:09 00000000  sqlite-amalgamation-3380400/
+ 8464186  Defl:N  2183655  74% 2022-05-04 18:09 337c2e0d  sqlite-amalgamation-3380400/sqlite3.c
+  725227  Defl:N   185189  75% 2022-05-04 18:09 0e743594  sqlite-amalgamation-3380400/shell.c
+   36750  Defl:N     6408  83% 2022-05-04 18:09 11790a34  sqlite-amalgamation-3380400/sqlite3ext.h
+  611797  Defl:N   158393  74% 2022-05-04 18:09 f220078b  sqlite-amalgamation-3380400/sqlite3.h
 --------          -------  ---                            -------
- 9837474          2533515  74%                            5 files
+ 9837960          2533645  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -14430,6 +14430,8 @@ static void exec_prepared_stmt_columnar(
   int bNextLine = 0;
   int bMultiLineRowExists = 0;
   int bw = p->cmOpts.bWordWrap;
+  const char *zEmpty = "";
+  const char *zShowNull = p->nullValue;
 
   rc = sqlite3_step(pStmt);
   if( rc!=SQLITE_ROW ) return;
@@ -14491,12 +14493,14 @@ static void exec_prepared_stmt_columnar(
       if( wx<0 ) wx = -wx;
       if( useNextLine ){
         uz = azNextLine[i];
+        if( uz==0 ) uz = (u8*)zEmpty;
       }else if( p->cmOpts.bQuote ){
         sqlite3_free(azQuoted[i]);
         azQuoted[i] = quoted_column(pStmt,i);
         uz = (const unsigned char*)azQuoted[i];
       }else{
         uz = (const unsigned char*)sqlite3_column_text(pStmt,i);
+        if( uz==0 ) uz = (u8*)zShowNull;
       }
       azData[nRow*nColumn + i]
         = translateForDisplayAndDup(uz, &azNextLine[i], wx, bw);
@@ -14510,7 +14514,7 @@ static void exec_prepared_stmt_columnar(
   nTotal = nColumn*(nRow+1);
   for(i=0; i<nTotal; i++){
     z = azData[i];
-    if( z==0 ) z = p->nullValue;
+    if( z==0 ) z = (char*)zEmpty;
     n = strlenChar(z);
     j = i%nColumn;
     if( n>p->actualWidth[j] ) p->actualWidth[j] = n;
@@ -14614,7 +14618,10 @@ columnar_end:
     utf8_printf(p->out, "Interrupt\n");
   }
   nData = (nRow+1)*nColumn;
-  for(i=0; i<nData; i++) free(azData[i]);
+  for(i=0; i<nData; i++){
+    z = azData[i];
+    if( z!=zEmpty && z!=zShowNull ) sqlite3_free(azData[i]);
+  }
   sqlite3_free(azData);
   sqlite3_free((void*)azNextLine);
   sqlite3_free(abRowDiv);
@@ -19040,12 +19047,12 @@ SELECT\
   ','||iif((cpos-1)%4>0, ' ', x'0a'||' '))\
  ||')' AS ColsSpec \
 FROM (\
- SELECT cpos, printf('\"%w\"',printf('%.*s%s', nlen-chop,name,suff)) AS cname \
+ SELECT cpos, printf('\"%w\"',printf('%!.*s%s', nlen-chop,name,suff)) AS cname \
  FROM ColNames ORDER BY cpos\
 )";
   static const char * const zRenamesDone =
     "SELECT group_concat("
-    " printf('\"%w\" to \"%w\"',name,printf('%.*s%s', nlen-chop, name, suff)),"
+    " printf('\"%w\" to \"%w\"',name,printf('%!.*s%s', nlen-chop, name, suff)),"
     " ','||x'0a')"
     "FROM ColNames WHERE suff<>'' OR chop!=0"
     ;

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.38.3"
-#define SQLITE_VERSION_NUMBER 3038003
-#define SQLITE_SOURCE_ID      "2022-04-27 12:03:15 9547e2c38a1c6f751a77d4d796894dec4dc5d8f5d79b1cd39e1ffc50df7b3be4"
+#define SQLITE_VERSION        "3.38.4"
+#define SQLITE_VERSION_NUMBER 3038004
+#define SQLITE_SOURCE_ID      "2022-05-04 15:45:55 d402f49871152670a62f4f28cacb15d814f2c1644e9347ad7d258e562978e45e"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.38.4 On 2022-05-04

1. Fix a byte-code problem in the Bloom filter pull-down optimization added by release 3.38.0 in which an error in the byte code causes the byte code engine to enter an infinite loop when the pull-down optimization encounters a NULL key. Forum thread 2482b32700384a0f.
2. Other minor patches. See the timeline for details.