### PR TITLE
Release/v3.38.5

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## SQLite Release 3.38.5 On 2022-05-06
+
+1. Fix a blunder in the CLI of the 3.38.4 release.
+
 ## SQLite Release 3.38.4 On 2022-05-04
 
 1. Fix a byte-code problem in the Bloom filter pull-down optimization added by release 3.38.0 in which an error in the byte code causes the byte code engine to enter an infinite loop when the pull-down optimization encounters a NULL key. Forum thread 2482b32700384a0f.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3380400.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3380500.zip
 
 ```
-Archive:  sqlite-amalgamation-3380400.zip
+Archive:  sqlite-amalgamation-3380500.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-05-04 18:09 00000000  sqlite-amalgamation-3380400/
- 8464186  Defl:N  2183655  74% 2022-05-04 18:09 337c2e0d  sqlite-amalgamation-3380400/sqlite3.c
-  725227  Defl:N   185189  75% 2022-05-04 18:09 0e743594  sqlite-amalgamation-3380400/shell.c
-   36750  Defl:N     6408  83% 2022-05-04 18:09 11790a34  sqlite-amalgamation-3380400/sqlite3ext.h
-  611797  Defl:N   158393  74% 2022-05-04 18:09 f220078b  sqlite-amalgamation-3380400/sqlite3.h
+       0  Stored        0   0% 2022-05-06 17:46 00000000  sqlite-amalgamation-3380500/
+ 8464417  Defl:N  2183732  74% 2022-05-06 17:46 df0e43a0  sqlite-amalgamation-3380500/sqlite3.c
+  725219  Defl:N   185190  75% 2022-05-06 17:46 37531ae3  sqlite-amalgamation-3380500/shell.c
+   36750  Defl:N     6408  83% 2022-05-06 17:46 11790a34  sqlite-amalgamation-3380500/sqlite3ext.h
+  611797  Defl:N   158391  74% 2022-05-06 17:46 362041e6  sqlite-amalgamation-3380500/sqlite3.h
 --------          -------  ---                            -------
- 9837960          2533645  74%                            5 files
+ 9838183          2533721  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -14620,7 +14620,7 @@ columnar_end:
   nData = (nRow+1)*nColumn;
   for(i=0; i<nData; i++){
     z = azData[i];
-    if( z!=zEmpty && z!=zShowNull ) sqlite3_free(azData[i]);
+    if( z!=zEmpty && z!=zShowNull ) free(azData[i]);
   }
   sqlite3_free(azData);
   sqlite3_free((void*)azNextLine);

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.38.4"
-#define SQLITE_VERSION_NUMBER 3038004
-#define SQLITE_SOURCE_ID      "2022-05-04 15:45:55 d402f49871152670a62f4f28cacb15d814f2c1644e9347ad7d258e562978e45e"
+#define SQLITE_VERSION        "3.38.5"
+#define SQLITE_VERSION_NUMBER 3038005
+#define SQLITE_SOURCE_ID      "2022-05-06 15:25:27 78d9c993d404cdfaa7fdd2973fa1052e3da9f66215cff9c5540ebe55c407d9fe"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.38.5 On 2022-05-06

1. Fix a blunder in the CLI of the 3.38.4 release.