### PR TITLE
Release/v3.39.1

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## SQLite Release 3.39.1 On 2022-07-13
+
+1. Fix an incorrect result from a query that uses a view that contains a compound SELECT in which only one arm contains a RIGHT JOIN and where the view is not the first FROM clause term of the query that contains the view. forum post 174afeae5734d42d.
+2. Fix some harmless compiler warnings.
+3. Fix a long-standing problem with ALTER TABLE RENAME that can only arise if the sqlite3_limit(SQLITE_LIMIT_SQL_LENGTH) is set to a very small value.
+4. Fix a long-standing problem in FTS3 that can only arise when compiled with the SQLITE_ENABLE_FTS3_PARENTHESIS compile-time option.
+5. Fix the build so that is works when the SQLITE_DEBUG and SQLITE_OMIT_WINDOWFUNC compile-time options are both provided at the same time.
+6. Fix the initial-prefix optimization for the REGEXP extension so that it works correctly even if the prefix contains characters that require a 3-byte UTF8 encoding.
+7. Enhance the sqlite_stmt virtual table so that it buffers all of its output.
+
 ## SQLite Release 3.39.0 On 2022-06-25
 
 1. Add (long overdue) support for RIGHT and FULL OUTER JOIN.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3390000.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3390100.zip
 
 ```
-Archive:  sqlite-amalgamation-3390000.zip
+Archive:  sqlite-amalgamation-3390100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-06-25 17:22 00000000  sqlite-amalgamation-3390000/
- 8544646  Defl:N  2202735  74% 2022-06-25 17:22 42029ae4  sqlite-amalgamation-3390000/sqlite3.c
-   37310  Defl:N     6493  83% 2022-06-25 17:22 a0ba1791  sqlite-amalgamation-3390000/sqlite3ext.h
-  613415  Defl:N   158836  74% 2022-06-25 17:22 d4fc51ed  sqlite-amalgamation-3390000/sqlite3.h
-  734132  Defl:N   187656  74% 2022-06-25 17:22 c5aa5ab6  sqlite-amalgamation-3390000/shell.c
+       0  Stored        0   0% 2022-07-13 22:35 00000000  sqlite-amalgamation-3390100/
+ 8546858  Defl:N  2203311  74% 2022-07-13 22:35 d011464c  sqlite-amalgamation-3390100/sqlite3.c
+   37310  Defl:N     6493  83% 2022-07-13 22:35 a0ba1791  sqlite-amalgamation-3390100/sqlite3ext.h
+  613416  Defl:N   158839  74% 2022-07-13 22:35 8ae9faca  sqlite-amalgamation-3390100/sqlite3.h
+  734132  Defl:N   187656  74% 2022-07-13 22:35 6acf1fdd  sqlite-amalgamation-3390100/shell.c
 --------          -------  ---                            -------
- 9929503          2555720  74%                            5 files
+ 9931716          2556299  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -4409,7 +4409,7 @@ static const char *re_compile(ReCompiled **ppRe, const char *zIn, int noCase){
         pRe->zInit[j++] = (unsigned char)(0xc0 | (x>>6));
         pRe->zInit[j++] = 0x80 | (x&0x3f);
       }else if( x<=0xffff ){
-        pRe->zInit[j++] = (unsigned char)(0xd0 | (x>>12));
+        pRe->zInit[j++] = (unsigned char)(0xe0 | (x>>12));
         pRe->zInit[j++] = 0x80 | ((x>>6)&0x3f);
         pRe->zInit[j++] = 0x80 | (x&0x3f);
       }else{

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.39.0"
-#define SQLITE_VERSION_NUMBER 3039000
-#define SQLITE_SOURCE_ID      "2022-06-25 14:57:57 14e166f40dbfa6e055543f8301525f2ca2e96a02a57269818b9e69e162e98918"
+#define SQLITE_VERSION        "3.39.1"
+#define SQLITE_VERSION_NUMBER 3039001
+#define SQLITE_SOURCE_ID      "2022-07-13 19:41:41 7c16541a0efb3985578181171c9f2bb3fdc4bad6a2ec85c6e31ab96f3eff201f"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -6282,7 +6282,7 @@ SQLITE_API sqlite3 *sqlite3_db_handle(sqlite3_stmt*);
 **
 ** ^The sqlite3_db_name(D,N) interface returns a pointer to the schema name
 ** for the N-th database on database connection D, or a NULL pointer of N is
-** out of range.  An N alue of 0 means the main database file.  An N of 1 is
+** out of range.  An N value of 0 means the main database file.  An N of 1 is
 ** the "temp" schema.  Larger values of N correspond to various ATTACH-ed
 ** databases.
 **


### PR DESCRIPTION
# SQLite Release 3.39.1 On 2022-07-13

1. Fix an incorrect result from a query that uses a view that contains a compound SELECT in which only one arm contains a RIGHT JOIN and where the view is not the first FROM clause term of the query that contains the view. forum post 174afeae5734d42d.
2. Fix some harmless compiler warnings.
3. Fix a long-standing problem with ALTER TABLE RENAME that can only arise if the sqlite3_limit(SQLITE_LIMIT_SQL_LENGTH) is set to a very small value.
4. Fix a long-standing problem in FTS3 that can only arise when compiled with the SQLITE_ENABLE_FTS3_PARENTHESIS compile-time option.
5. Fix the build so that is works when the SQLITE_DEBUG and SQLITE_OMIT_WINDOWFUNC compile-time options are both provided at the same time.
6. Fix the initial-prefix optimization for the REGEXP extension so that it works correctly even if the prefix contains characters that require a 3-byte UTF8 encoding.
7. Enhance the sqlite_stmt virtual table so that it buffers all of its output.