### PR TITLE
Release/v3.39.2

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## SQLite Release 3.39.2 On 2022-07-21
+
+1. Fix a performance regression in the query planner associated with rearranging the order of FROM clause terms in the presences of a LEFT JOIN.
+2. Apply fixes for CVE-2022-35737, Chromium bugs 1343348 and 1345947, forum post 3607259d3c, and other minor problems discovered by internal testing.
+
 ## SQLite Release 3.39.1 On 2022-07-13
 
 1. Fix an incorrect result from a query that uses a view that contains a compound SELECT in which only one arm contains a RIGHT JOIN and where the view is not the first FROM clause term of the query that contains the view. forum post 174afeae5734d42d.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3390100.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3390200.zip
 
 ```
-Archive:  sqlite-amalgamation-3390100.zip
+Archive:  sqlite-amalgamation-3390200.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-07-13 22:35 00000000  sqlite-amalgamation-3390100/
- 8546858  Defl:N  2203311  74% 2022-07-13 22:35 d011464c  sqlite-amalgamation-3390100/sqlite3.c
-   37310  Defl:N     6493  83% 2022-07-13 22:35 a0ba1791  sqlite-amalgamation-3390100/sqlite3ext.h
-  613416  Defl:N   158839  74% 2022-07-13 22:35 8ae9faca  sqlite-amalgamation-3390100/sqlite3.h
-  734132  Defl:N   187656  74% 2022-07-13 22:35 6acf1fdd  sqlite-amalgamation-3390100/shell.c
+       0  Stored        0   0% 2022-07-21 18:02 00000000  sqlite-amalgamation-3390200/
+ 8546396  Defl:N  2203141  74% 2022-07-21 18:02 1cdbe736  sqlite-amalgamation-3390200/sqlite3.c
+   37310  Defl:N     6493  83% 2022-07-21 18:02 a0ba1791  sqlite-amalgamation-3390200/sqlite3ext.h
+  613416  Defl:N   158842  74% 2022-07-21 18:02 43cc284b  sqlite-amalgamation-3390200/sqlite3.h
+  734131  Defl:N   187656  74% 2022-07-21 18:02 9c6abb29  sqlite-amalgamation-3390200/shell.c
 --------          -------  ---                            -------
- 9931716          2556299  74%                            5 files
+ 9931253          2556132  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -23078,7 +23078,7 @@ int SQLITE_CDECL wmain(int argc, wchar_t **wargv){
   char **argv;
 #endif
 #ifdef SQLITE_DEBUG
-  sqlite3_uint64 mem_main_enter = sqlite3_memory_used();
+  sqlite3_int64 mem_main_enter = sqlite3_memory_used();
 #endif
   char *zErrMsg = 0;
 #ifdef SQLITE_SHELL_WASM_MODE

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.39.1"
-#define SQLITE_VERSION_NUMBER 3039001
-#define SQLITE_SOURCE_ID      "2022-07-13 19:41:41 7c16541a0efb3985578181171c9f2bb3fdc4bad6a2ec85c6e31ab96f3eff201f"
+#define SQLITE_VERSION        "3.39.2"
+#define SQLITE_VERSION_NUMBER 3039002
+#define SQLITE_SOURCE_ID      "2022-07-21 15:24:47 698edb77537b67c41adc68f9b892db56bcf9a55e00371a61420f3ddd668e6603"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.39.2 On 2022-07-21

1. Fix a performance regression in the query planner associated with rearranging the order of FROM clause terms in the presences of a LEFT JOIN.
2. Apply fixes for CVE-2022-35737, Chromium bugs 1343348 and 1345947, forum post 3607259d3c, and other minor problems discovered by internal testing.