### PR TITLE
Release/v3.39.3

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## SQLite Release 3.39.3 On 2022-09-05
+
+1. Use a statement journal on DML statement affecting two or more database rows if the statement makes use of a SQL functions that might abort. See forum thread 9b9e4716c0d7bbd1.
+2. Use a mutex to protect the PRAGMA temp_store_directory and PRAGMA data_store_directory statements, even though they are deprecated and documented as not being threadsafe. See forum post 719a11e1314d1c70.
+3. Other bug and warning fixes. See the timeline for details.
+
 ## SQLite Release 3.39.2 On 2022-07-21
 
 1. Fix a performance regression in the query planner associated with rearranging the order of FROM clause terms in the presences of a LEFT JOIN.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3390200.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3390300.zip
 
 ```
-Archive:  sqlite-amalgamation-3390200.zip
+Archive:  sqlite-amalgamation-3390300.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-07-21 18:02 00000000  sqlite-amalgamation-3390200/
- 8546396  Defl:N  2203141  74% 2022-07-21 18:02 1cdbe736  sqlite-amalgamation-3390200/sqlite3.c
-   37310  Defl:N     6493  83% 2022-07-21 18:02 a0ba1791  sqlite-amalgamation-3390200/sqlite3ext.h
-  613416  Defl:N   158842  74% 2022-07-21 18:02 43cc284b  sqlite-amalgamation-3390200/sqlite3.h
-  734131  Defl:N   187656  74% 2022-07-21 18:02 9c6abb29  sqlite-amalgamation-3390200/shell.c
+       0  Stored        0   0% 2022-09-05 13:28 00000000  sqlite-amalgamation-3390300/
+ 8549001  Defl:N  2203624  74% 2022-09-05 13:28 ce175808  sqlite-amalgamation-3390300/sqlite3.c
+   37310  Defl:N     6493  83% 2022-09-05 13:28 a0ba1791  sqlite-amalgamation-3390300/sqlite3ext.h
+  613416  Defl:N   158840  74% 2022-09-05 13:28 7e2157d5  sqlite-amalgamation-3390300/sqlite3.h
+  734131  Defl:N   187656  74% 2022-09-05 13:28 9c6abb29  sqlite-amalgamation-3390300/shell.c
 --------          -------  ---                            -------
- 9931253          2556132  74%                            5 files
+ 9933858          2556613  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.39.2"
-#define SQLITE_VERSION_NUMBER 3039002
-#define SQLITE_SOURCE_ID      "2022-07-21 15:24:47 698edb77537b67c41adc68f9b892db56bcf9a55e00371a61420f3ddd668e6603"
+#define SQLITE_VERSION        "3.39.3"
+#define SQLITE_VERSION_NUMBER 3039003
+#define SQLITE_SOURCE_ID      "2022-09-05 11:02:23 4635f4a69c8c2a8df242b384a992aea71224e39a2ccab42d8c0b0602f1e826e8"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.39.3 On 2022-09-05

1. Use a statement journal on DML statement affecting two or more database rows if the statement makes use of a SQL functions that might abort. See forum thread 9b9e4716c0d7bbd1.
2. Use a mutex to protect the PRAGMA temp_store_directory and PRAGMA data_store_directory statements, even though they are deprecated and documented as not being threadsafe. See forum post 719a11e1314d1c70.
3. Other bug and warning fixes. See the timeline for details.