### PR TITLE
Release/v3.39.4

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## SQLite Release 3.39.4 On 2022-09-29
+
+1. Fix the build on Windows so that it works with -DSQLITE_OMIT_AUTOINIT
+2. Fix a long-standing problem in the btree balancer that might, in rare cases, cause database corruption if the application uses an application-defined page cache.
+3. Enhance SQLITE_DBCONFIG_DEFENSIVE so that it disallows CREATE TRIGGER statements if one or more of the statements in the body of the trigger write into shadow tables.
+4. Fix a possible integer overflow in the size computation for a memory allocation in FTS3.
+5. Fix a misuse of the sqlite3_set_auxdata() interface in the ICU Extension.
+
 ## SQLite Release 3.39.3 On 2022-09-05
 
 1. Use a statement journal on DML statement affecting two or more database rows if the statement makes use of a SQL functions that might abort. See forum thread 9b9e4716c0d7bbd1.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3390300.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3390400.zip
 
 ```
-Archive:  sqlite-amalgamation-3390300.zip
+Archive:  sqlite-amalgamation-3390400.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-09-05 13:28 00000000  sqlite-amalgamation-3390300/
- 8549001  Defl:N  2203624  74% 2022-09-05 13:28 ce175808  sqlite-amalgamation-3390300/sqlite3.c
-   37310  Defl:N     6493  83% 2022-09-05 13:28 a0ba1791  sqlite-amalgamation-3390300/sqlite3ext.h
-  613416  Defl:N   158840  74% 2022-09-05 13:28 7e2157d5  sqlite-amalgamation-3390300/sqlite3.h
-  734131  Defl:N   187656  74% 2022-09-05 13:28 9c6abb29  sqlite-amalgamation-3390300/shell.c
+       0  Stored        0   0% 2022-09-29 18:01 00000000  sqlite-amalgamation-3390400/
+ 8550097  Defl:N  2203866  74% 2022-09-29 18:01 dc690f28  sqlite-amalgamation-3390400/sqlite3.c
+   37310  Defl:N     6493  83% 2022-09-29 18:01 a0ba1791  sqlite-amalgamation-3390400/sqlite3ext.h
+  613416  Defl:N   158842  74% 2022-09-29 18:01 5f44c33e  sqlite-amalgamation-3390400/sqlite3.h
+  734131  Defl:N   187656  74% 2022-09-29 18:01 9c6abb29  sqlite-amalgamation-3390400/shell.c
 --------          -------  ---                            -------
- 9933858          2556613  74%                            5 files
+ 9934954          2556857  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.39.3"
-#define SQLITE_VERSION_NUMBER 3039003
-#define SQLITE_SOURCE_ID      "2022-09-05 11:02:23 4635f4a69c8c2a8df242b384a992aea71224e39a2ccab42d8c0b0602f1e826e8"
+#define SQLITE_VERSION        "3.39.4"
+#define SQLITE_VERSION_NUMBER 3039004
+#define SQLITE_SOURCE_ID      "2022-09-29 15:55:41 a29f9949895322123f7c38fbe94c649a9d6e6c9cd0c3b41c96d694552f26b309"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.39.4 On 2022-09-29

1. Fix the build on Windows so that it works with -DSQLITE_OMIT_AUTOINIT
2. Fix a long-standing problem in the btree balancer that might, in rare cases, cause database corruption if the application uses an application-defined page cache.
3. Enhance SQLITE_DBCONFIG_DEFENSIVE so that it disallows CREATE TRIGGER statements if one or more of the statements in the body of the trigger write into shadow tables.
4. Fix a possible integer overflow in the size computation for a memory allocation in FTS3.
5. Fix a misuse of the sqlite3_set_auxdata() interface in the ICU Extension.