### PR TITLE
Release/v3.40.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,8 @@ choice(SQLITE_DQS "Enable DQS: 0 = None (recommended); 1 = DML; 2 = DDL; 3 = Bot
 choice(SQLITE_THREADSAFE "Select the thread model: 0 = single-threaded; 1 = serialized (default); 2 = multi-threaded."
     VALID_VALUES 0 1 2 DEFAULT 1 FATAL_ERROR)
 
-set(SQLITE_MAX_EXPR_DEPTH 1000 CACHE STRING "Set the maximum expression tree depth.")
+set(SQLITE_MAX_ALLOCATION_SIZE -1 CACHE STRING "Set an upper bound on the size of memory allocations.")
+set(SQLITE_MAX_EXPR_DEPTH -1 CACHE STRING "Set the maximum expression tree depth.")
 
 option(SQLITE_ENABLE_API_ARMOR "This option activates extra code that attempts to detect misuse of the SQLite API." OFF)
 option(SQLITE_ENABLE_COLUMN_METADATA "Enable some extra APIs that are required by some common systems, including Ruby-on-Rails." OFF)
@@ -101,7 +102,11 @@ if(SQLITE_ENABLE_SESSION AND NOT SQLITE_ENABLE_PREUPDATE_HOOK)
     message(SEND_ERROR "Option SQLITE_ENABLE_SESSION requires option SQLITE_ENABLE_PREUPDATE_HOOK.")
 endif()
 
-if(NOT SQLITE_MAX_EXPR_DEPTH GREATER_EQUAL 0)
+if(NOT SQLITE_MAX_ALLOCATION_SIZE GREATER_EQUAL -1)
+    message(SEND_ERROR "Configuration SQLITE_MAX_ALLOCATION_SIZE=${SQLITE_MAX_ALLOCATION_SIZE} is not valid.")
+endif()
+
+if(NOT SQLITE_MAX_EXPR_DEPTH GREATER_EQUAL -1)
     message(SEND_ERROR "Configuration SQLITE_MAX_EXPR_DEPTH=${SQLITE_MAX_EXPR_DEPTH} is not valid.")
 endif()
 
@@ -215,8 +220,9 @@ target_compile_definitions(SQLite3
         SQLITE_DEFAULT_SYNCHRONOUS=${SQLITE_DEFAULT_SYNCHRONOUS}
         SQLITE_DEFAULT_WAL_SYNCHRONOUS=${SQLITE_DEFAULT_WAL_SYNCHRONOUS}
         SQLITE_DQS=${SQLITE_DQS}
-        SQLITE_MAX_EXPR_DEPTH=${SQLITE_MAX_EXPR_DEPTH}
         SQLITE_THREADSAFE=${SQLITE_THREADSAFE}
+        $<$<NOT:$<STREQUAL:${SQLITE_MAX_ALLOCATION_SIZE},-1>>:SQLITE_MAX_ALLOCATION_SIZE=${SQLITE_MAX_ALLOCATION_SIZE}>
+        $<$<NOT:$<STREQUAL:${SQLITE_MAX_EXPR_DEPTH},-1>>:SQLITE_MAX_EXPR_DEPTH=${SQLITE_MAX_EXPR_DEPTH}>
         $<$<BOOL:${SQLITE_ENABLE_API_ARMOR}>:SQLITE_ENABLE_API_ARMOR>
         $<$<BOOL:${SQLITE_ENABLE_COLUMN_METADATA}>:SQLITE_ENABLE_COLUMN_METADATA>
         $<$<BOOL:${SQLITE_ENABLE_DBSTAT_VTAB}>:SQLITE_ENABLE_DBSTAT_VTAB>

--- a/README.md
+++ b/README.md
@@ -94,9 +94,12 @@ system if you need them.
   LIKE optimization to run faster.
 
 - `SQLITE_MAX_EXPR_DEPTH:STRING`=**0**:
-  value is an **integer**, default = **1000**.  
+  value is an **integer**, default = **-1**.  
   This option determines the maximum expression tree depth. If the value is
   **0**, then no limit is enforced. The recommended value is **0** (no limit).
+
+  *Special value **-1** does not get passed to the build generator,
+  so that the source code uses its own default.*
 
 - `SQLITE_ENABLE_COLUMN_METADATA:BOOL`=**OFF**:
   value is a **boolean**, default = **OFF**.  
@@ -208,6 +211,14 @@ system if you need them.
 - `SQLITE_ENABLE_STMTVTAB:BOOL`=**OFF**:
   value is a **boolean**.  
   This compile-time option enables the SQLITE_STMT virtual table logic.
+
+- `SQLITE_MAX_ALLOCATION_SIZE:STRING`=**-1**:
+  value is an **integer**.  
+  This option sets an upper bound on the size of memory allocations that can be
+  requested using sqlite3_malloc64(), sqlite3_realloc64(), and similar.
+
+  *Special value **-1** does not get passed to the build generator,
+  so that the source code uses its own default.*
 
 - `SQLITE_OMIT_DESERIALIZE:BOOL`=**OFF**:
   value is a **boolean**.  

--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## SQLite Release 3.40.0 On 2022-11-16
+
+1. Add support for compiling SQLite to WASM and running it in web browsers. NB: The WASM build and its interfaces are considered "beta" and are subject to minor changes if the need arises. We anticipate finalizing the interface for the next release.
+2. Add the recovery extension that might be able to recover some content from a corrupt database file.
+3. Query planner enhancements:
+    1. Recognize covering indexes on tables with more than 63 columns where columns beyond the 63rd column are used in the query and/or are referenced by the index.
+    2. Extract the values of expressions contained within expression indexes where practical, rather than recomputing the expression.
+    3. The NOT NULL and IS NULL operators (and their equivalents) avoid loading the content of large strings and BLOB values from disk.
+    4. Avoid materializing a view on which a full scan is performed exactly once. Use and discard the rows of the view as they are computed.
+    5. Allow flattening of a subquery that is the right-hand operand of a LEFT JOIN in an aggregate query.
+4. A new typedef named sqlite3_filename is added and used to represent the name of a database file. Various interfaces are modified to use the new typedef instead of "char*". This interface change should be fully backwards compatible, though it might cause (harmless) compiler warnings when rebuilding some legacy applications.
+5. Add the sqlite3_value_encoding() interface.
+6. Security enhancement: SQLITE_DBCONFIG_DEFENSIVE is augmented to prohibit changing the schema_version. The schema_version becomes read-only in defensive mode.
+7. Enhancements to the PRAGMA integrity_check statement:
+    1. Columns in non-STRICT tables with TEXT affinity should not contain numeric values.
+    2. Columns in non-STRICT tables with NUMERIC affinity should not contain TEXT values that could be converted into numbers.
+    3. Verify that the rows of a WITHOUT ROWID table are in the correct order.
+8. Enhance the VACUUM INTO statement so that it honors the PRAGMA synchronous setting.
+9. Enhance the sqlite3_strglob() and sqlite3_strlike() APIs so that they are able to accept NULL pointers for their string parameters and still generate a sensible result.
+10. Provide the new SQLITE_MAX_ALLOCATION_SIZE compile-time option for limiting the size of memory allocations.
+11. Change the algorithm used by SQLite's built-in pseudo-random number generator (PRNG) from RC4 to Chacha20.
+12. Allow two or more indexes to have the same name as long as they are all in separate schemas.
+13. Miscellaneous performance optimizations result in about 1% fewer CPU cycles used on typical workloads.
+
 ## SQLite Release 3.39.4 On 2022-09-29
 
 1. Fix the build on Windows so that it works with -DSQLITE_OMIT_AUTOINIT

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3390400.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3400000.zip
 
 ```
-Archive:  sqlite-amalgamation-3390400.zip
+Archive:  sqlite-amalgamation-3400000.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-09-29 18:01 00000000  sqlite-amalgamation-3390400/
- 8550097  Defl:N  2203866  74% 2022-09-29 18:01 dc690f28  sqlite-amalgamation-3390400/sqlite3.c
-   37310  Defl:N     6493  83% 2022-09-29 18:01 a0ba1791  sqlite-amalgamation-3390400/sqlite3ext.h
-  613416  Defl:N   158842  74% 2022-09-29 18:01 5f44c33e  sqlite-amalgamation-3390400/sqlite3.h
-  734131  Defl:N   187656  74% 2022-09-29 18:01 9c6abb29  sqlite-amalgamation-3390400/shell.c
+       0  Stored        0   0% 2022-11-16 14:42 00000000  sqlite-amalgamation-3400000/
+ 8611069  Defl:N  2219018  74% 2022-11-16 14:42 7a13b10f  sqlite-amalgamation-3400000/sqlite3.c
+  819729  Defl:N   209204  75% 2022-11-16 14:42 64991f4d  sqlite-amalgamation-3400000/shell.c
+  616004  Defl:N   159512  74% 2022-11-16 14:42 eb1faf1e  sqlite-amalgamation-3400000/sqlite3.h
+   37494  Defl:N     6523  83% 2022-11-16 14:42 d33a365a  sqlite-amalgamation-3400000/sqlite3ext.h
 --------          -------  ---                            -------
- 9934954          2556857  74%                            5 files
+10084296          2594257  74%                            5 files
 ```

--- a/source/sqlite3ext.h
+++ b/source/sqlite3ext.h
@@ -331,9 +331,9 @@ struct sqlite3_api_routines {
   const char *(*filename_journal)(const char*);
   const char *(*filename_wal)(const char*);
   /* Version 3.32.0 and later */
-  char *(*create_filename)(const char*,const char*,const char*,
+  const char *(*create_filename)(const char*,const char*,const char*,
                            int,const char**);
-  void (*free_filename)(char*);
+  void (*free_filename)(const char*);
   sqlite3_file *(*database_file_object)(const char*);
   /* Version 3.34.0 and later */
   int (*txn_state)(sqlite3*,const char*);
@@ -357,6 +357,8 @@ struct sqlite3_api_routines {
   unsigned char *(*serialize)(sqlite3*,const char *,sqlite3_int64*,
                               unsigned int);
   const char *(*db_name)(sqlite3*,int);
+  /* Version 3.40.0 and later */
+  int (*value_encoding)(sqlite3_value*);
 };
 
 /*
@@ -681,6 +683,8 @@ typedef int (*sqlite3_loadext_entry)(
 #define sqlite3_serialize              sqlite3_api->serialize
 #endif
 #define sqlite3_db_name                sqlite3_api->db_name
+/* Version 3.40.0 and later */
+#define sqlite3_value_encoding         sqlite3_api->value_encoding
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)


### PR DESCRIPTION
# SQLite Release 3.40.0 On 2022-11-16

1. Add support for compiling SQLite to WASM and running it in web browsers. NB: The WASM build and its interfaces are considered "beta" and are subject to minor changes if the need arises. We anticipate finalizing the interface for the next release.
2. Add the recovery extension that might be able to recover some content from a corrupt database file.
3. Query planner enhancements:
    1. Recognize covering indexes on tables with more than 63 columns where columns beyond the 63rd column are used in the query and/or are referenced by the index.
    2. Extract the values of expressions contained within expression indexes where practical, rather than recomputing the expression.
    3. The NOT NULL and IS NULL operators (and their equivalents) avoid loading the content of large strings and BLOB values from disk.
    4. Avoid materializing a view on which a full scan is performed exactly once. Use and discard the rows of the view as they are computed.
    5. Allow flattening of a subquery that is the right-hand operand of a LEFT JOIN in an aggregate query.
4. A new typedef named sqlite3_filename is added and used to represent the name of a database file. Various interfaces are modified to use the new typedef instead of "char*". This interface change should be fully backwards compatible, though it might cause (harmless) compiler warnings when rebuilding some legacy applications.
5. Add the sqlite3_value_encoding() interface.
6. Security enhancement: SQLITE_DBCONFIG_DEFENSIVE is augmented to prohibit changing the schema_version. The schema_version becomes read-only in defensive mode.
7. Enhancements to the PRAGMA integrity_check statement:
    1. Columns in non-STRICT tables with TEXT affinity should not contain numeric values.
    2. Columns in non-STRICT tables with NUMERIC affinity should not contain TEXT values that could be converted into numbers.
    3. Verify that the rows of a WITHOUT ROWID table are in the correct order.
8. Enhance the VACUUM INTO statement so that it honors the PRAGMA synchronous setting.
9. Enhance the sqlite3_strglob() and sqlite3_strlike() APIs so that they are able to accept NULL pointers for their string parameters and still generate a sensible result.
10. Provide the new SQLITE_MAX_ALLOCATION_SIZE compile-time option for limiting the size of memory allocations.
11. Change the algorithm used by SQLite's built-in pseudo-random number generator (PRNG) from RC4 to Chacha20.
12. Allow two or more indexes to have the same name as long as they are all in separate schemas.
13. Miscellaneous performance optimizations result in about 1% fewer CPU cycles used on typical workloads.