### PR TITLE
Release/v3.40.1

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## SQLite Release 3.40.1 On 2022-12-28
+
+1. Fix the --safe command-line option to the CLI such that it correctly disallows the use of SQL functions like writefile() that can cause harmful side-effects.
+2. Fix a potential infinite loop in the memsys5 alternative memory allocator. This bug was introduced by a performance optimization in version 3.39.0.
+3. Various other obscure fixes.
+
 ## SQLite Release 3.40.0 On 2022-11-16
 
 1. Add support for compiling SQLite to WASM and running it in web browsers. NB: The WASM build and its interfaces are considered "beta" and are subject to minor changes if the need arises. We anticipate finalizing the interface for the next release.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2022/sqlite-amalgamation-3400000.zip
+Download: https://sqlite.org/2022/sqlite-amalgamation-3400100.zip
 
 ```
-Archive:  sqlite-amalgamation-3400000.zip
+Archive:  sqlite-amalgamation-3400100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2022-11-16 14:42 00000000  sqlite-amalgamation-3400000/
- 8611069  Defl:N  2219018  74% 2022-11-16 14:42 7a13b10f  sqlite-amalgamation-3400000/sqlite3.c
-  819729  Defl:N   209204  75% 2022-11-16 14:42 64991f4d  sqlite-amalgamation-3400000/shell.c
-  616004  Defl:N   159512  74% 2022-11-16 14:42 eb1faf1e  sqlite-amalgamation-3400000/sqlite3.h
-   37494  Defl:N     6523  83% 2022-11-16 14:42 d33a365a  sqlite-amalgamation-3400000/sqlite3ext.h
+       0  Stored        0   0% 2022-12-28 15:26 00000000  sqlite-amalgamation-3400100/
+ 8614007  Defl:N  2219684  74% 2022-12-28 15:26 6675ec1c  sqlite-amalgamation-3400100/sqlite3.c
+  819978  Defl:N   209257  75% 2022-12-28 15:26 cf57203c  sqlite-amalgamation-3400100/shell.c
+  616357  Defl:N   159605  74% 2022-12-28 15:26 77050bd0  sqlite-amalgamation-3400100/sqlite3.h
+   37494  Defl:N     6523  83% 2022-12-28 15:26 d33a365a  sqlite-amalgamation-3400100/sqlite3ext.h
 --------          -------  ---                            -------
-10084296          2594257  74%                            5 files
+10087836          2595069  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.40.0"
-#define SQLITE_VERSION_NUMBER 3040000
-#define SQLITE_SOURCE_ID      "2022-11-16 12:10:08 89c459e766ea7e9165d0beeb124708b955a4950d0f4792f457465d71b158d318"
+#define SQLITE_VERSION        "3.40.1"
+#define SQLITE_VERSION_NUMBER 3040001
+#define SQLITE_SOURCE_ID      "2022-12-28 14:03:47 df5c253c0b3dd24916e4ec7cf77d3db5294cc9fd45ae7b9c5e82ad8197f38a24"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -1192,6 +1192,12 @@ struct sqlite3_io_methods {
 **
 ** <li>[[SQLITE_FCNTL_CKSM_FILE]]
 ** Used by the cksmvfs VFS module only.
+**
+** <li>[[SQLITE_FCNTL_RESET_CACHE]]
+** If there is currently no transaction open on the database, and the
+** database is not a temp db, then this file-control purges the contents
+** of the in-memory page cache. If there is an open transaction, or if
+** the db is a temp-db, it is a no-op, not an error.
 ** </ul>
 */
 #define SQLITE_FCNTL_LOCKSTATE               1
@@ -1234,6 +1240,7 @@ struct sqlite3_io_methods {
 #define SQLITE_FCNTL_CKPT_START             39
 #define SQLITE_FCNTL_EXTERNAL_READER        40
 #define SQLITE_FCNTL_CKSM_FILE              41
+#define SQLITE_FCNTL_RESET_CACHE            42
 
 /* deprecated names */
 #define SQLITE_GET_LOCKPROXYFILE      SQLITE_FCNTL_GET_LOCKPROXYFILE


### PR DESCRIPTION
# SQLite Release 3.40.1 On 2022-12-28

1. Fix the --safe command-line option to the CLI such that it correctly disallows the use of SQL functions like writefile() that can cause harmful side-effects.
2. Fix a potential infinite loop in the memsys5 alternative memory allocator. This bug was introduced by a performance optimization in version 3.39.0.
3. Various other obscure fixes.
