### PR TITLE
Release/v3.41.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ 'release/**', 'feature/**' ]
+    branches: [ 'feature/**', '*fix/**', 'release/**' ]
   pull_request:
     branches: [ 'main' ]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,11 @@ endif()
 
 # -- Introspection -------------------------------------------------------------
 
+if(CMAKE_C_COMPILER_ID MATCHES "(GNU|Clang)")
+    list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES m)
+endif()
+
 include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(CheckTypeSize)
@@ -131,6 +136,8 @@ check_include_file(malloc.h HAVE_MALLOC_H)
 check_symbol_exists(malloc_usable_size malloc.h HAVE_MALLOC_USABLE_SIZE)
 
 check_symbol_exists(isnan math.h HAVE_ISNAN)
+check_symbol_exists(log2 math.h HAVE_LOG2)
+check_symbol_exists(log10 math.h HAVE_LOG10)
 
 check_symbol_exists(strchrnul string.h HAVE_STRCHRNUL)
 check_symbol_exists(strerror_r string.h HAVE_STRERROR_R)
@@ -257,6 +264,8 @@ target_compile_definitions(SQLite3
         $<$<BOOL:${HAVE_ISNAN}>:HAVE_ISNAN>
         $<$<BOOL:${HAVE_LOCALTIME_R}>:HAVE_LOCALTIME_R>
         $<$<BOOL:${HAVE_LOCALTIME_S}>:HAVE_LOCALTIME_S>
+        HAVE_LOG2=$<BOOL:${HAVE_LOG2}>
+        HAVE_LOG10=$<BOOL:${HAVE_LOG10}>
         $<$<BOOL:${HAVE_LSTAT}>:HAVE_LSTAT>
         $<$<BOOL:${HAVE_MALLOC_H}>:HAVE_MALLOC_H>
         $<$<BOOL:${HAVE_MALLOC_USABLE_SIZE}>:HAVE_MALLOC_USABLE_SIZE>

--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## SQLite Release 3.41.1 On 2023-03-10
+
+1. Provide compile-time options -DHAVE_LOG2=0 and -DHAVE_LOG10=0 to enable SQLite to be compiled on systems that omit the standard library functions log2() and log10(), repectively.
+2. Ensure that the datatype for column t1.x in "CREATE TABLE t1 AS SELECT CAST(7 AS INT) AS x;" continues to be INT and is not NUM, for historical compatibility.
+3. Enhance PRAGMA integrity_check to detect when extra bytes appear at the end of an index record.
+4. Fix various obscure bugs reported by the user community. See the timeline of changes for details.
+
 ## SQLite Release 3.41.0 On 2023-02-21
 
 1. Query planner improvements:

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2023/sqlite-amalgamation-3410000.zip
+Download: https://sqlite.org/2023/sqlite-amalgamation-3410100.zip
 
 ```
-Archive:  sqlite-amalgamation-3410000.zip
+Archive:  sqlite-amalgamation-3410100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2023-02-21 20:38 00000000  sqlite-amalgamation-3410000/
- 8666675  Defl:N  2234435  74% 2023-02-21 20:38 67bdd1ee  sqlite-amalgamation-3410000/sqlite3.c
-  854289  Defl:N   219374  74% 2023-02-21 20:38 5dc2b9a7  sqlite-amalgamation-3410000/shell.c
-  620239  Defl:N   160687  74% 2023-02-21 20:38 2ddb4c51  sqlite-amalgamation-3410000/sqlite3.h
-   37660  Defl:N     6552  83% 2023-02-21 20:38 4d9fb602  sqlite-amalgamation-3410000/sqlite3ext.h
+       0  Stored        0   0% 2023-03-10 14:59 00000000  sqlite-amalgamation-3410100/
+ 8668959  Defl:N  2235099  74% 2023-03-10 14:59 a1fb1630  sqlite-amalgamation-3410100/sqlite3.c
+  854289  Defl:N   219374  74% 2023-03-10 14:59 5dc2b9a7  sqlite-amalgamation-3410100/shell.c
+  620239  Defl:N   160684  74% 2023-03-10 14:59 e198947d  sqlite-amalgamation-3410100/sqlite3.h
+   37660  Defl:N     6552  83% 2023-03-10 14:59 4d9fb602  sqlite-amalgamation-3410100/sqlite3ext.h
 --------          -------  ---                            -------
-10178863          2621048  74%                            5 files
+10181147          2621709  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.41.0"
-#define SQLITE_VERSION_NUMBER 3041000
-#define SQLITE_SOURCE_ID      "2023-02-21 18:09:37 05941c2a04037fc3ed2ffae11f5d2260706f89431f463518740f72ada350866d"
+#define SQLITE_VERSION        "3.41.1"
+#define SQLITE_VERSION_NUMBER 3041001
+#define SQLITE_SOURCE_ID      "2023-03-10 12:13:52 20399f3eda5ec249d147ba9e48da6e87f969d7966a9a896764ca437ff7e737ff"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.41.1 On 2023-03-10

1. Provide compile-time options -DHAVE_LOG2=0 and -DHAVE_LOG10=0 to enable SQLite to be compiled on systems that omit the standard library functions log2() and log10(), repectively.
2. Ensure that the datatype for column t1.x in "CREATE TABLE t1 AS SELECT CAST(7 AS INT) AS x;" continues to be INT and is not NUM, for historical compatibility.
3. Enhance PRAGMA integrity_check to detect when extra bytes appear at the end of an index record.
4. Fix various obscure bugs reported by the user community. See the timeline of changes for details.