### PR TITLE
SQLite Release 3.41.2 On 2023-03-22

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## SQLite Release 3.41.2 On 2023-03-22
+
+1. Multiple fixes for reads past the end of memory buffers (NB: reads not writes) in the following circumstances:
+    1. When processing a corrupt database file using the non-standard SQLITE_ENABLE_STAT4 compile-time option.
+    2. In the CLI when the sqlite3_error_offset() routine returns an out-of-range value (see also the fix to sqlite3_error_offset() below).
+    3. In the recovery extension.
+    4. In FTS3 when processing a corrupt database file.
+2. Fix the sqlite3_error_offset() so that it does not return out-of-range values when reporting errors associated with generated columns.
+3. Multiple fixes in the query optimizer for problems that cause incorrect results for bizarre, fuzzer-generated queries.
+4. Increase the size of the reference counter in the page cache object to 64 bits to ensure that the counter never overflows.
+5. Fix a performance regression caused by a bug fix in patch release 3.41.1.
+6. Fix a few incorrect assert() statements.
+
 ## SQLite Release 3.41.1 On 2023-03-10
 
 1. Provide compile-time options -DHAVE_LOG2=0 and -DHAVE_LOG10=0 to enable SQLite to be compiled on systems that omit the standard library functions log2() and log10(), repectively.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2023/sqlite-amalgamation-3410100.zip
+Download: https://sqlite.org/2023/sqlite-amalgamation-3410200.zip
 
 ```
-Archive:  sqlite-amalgamation-3410100.zip
+Archive:  sqlite-amalgamation-3410200.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2023-03-10 14:59 00000000  sqlite-amalgamation-3410100/
- 8668959  Defl:N  2235099  74% 2023-03-10 14:59 a1fb1630  sqlite-amalgamation-3410100/sqlite3.c
-  854289  Defl:N   219374  74% 2023-03-10 14:59 5dc2b9a7  sqlite-amalgamation-3410100/shell.c
-  620239  Defl:N   160684  74% 2023-03-10 14:59 e198947d  sqlite-amalgamation-3410100/sqlite3.h
-   37660  Defl:N     6552  83% 2023-03-10 14:59 4d9fb602  sqlite-amalgamation-3410100/sqlite3ext.h
+       0  Stored        0   0% 2023-03-22 14:45 00000000  sqlite-amalgamation-3410200/
+ 8670021  Defl:N  2235420  74% 2023-03-22 14:45 90597981  sqlite-amalgamation-3410200/sqlite3.c
+  854392  Defl:N   219406  74% 2023-03-22 14:45 6aca6454  sqlite-amalgamation-3410200/shell.c
+  620239  Defl:N   160684  74% 2023-03-22 14:45 20da5e79  sqlite-amalgamation-3410200/sqlite3.h
+   37660  Defl:N     6552  83% 2023-03-22 14:45 4d9fb602  sqlite-amalgamation-3410200/sqlite3ext.h
 --------          -------  ---                            -------
-10181147          2621709  74%                            5 files
+10182312          2622062  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -13023,10 +13023,14 @@ static int dbdataNext(sqlite3_vtab_cursor *pCursor){
         if( pCsr->bOnePage==0 && pCsr->iPgno>pCsr->szDb ) return SQLITE_OK;
         rc = dbdataLoadPage(pCsr, pCsr->iPgno, &pCsr->aPage, &pCsr->nPage);
         if( rc!=SQLITE_OK ) return rc;
-        if( pCsr->aPage ) break;
+        if( pCsr->aPage && pCsr->nPage>=256 ) break;
+        sqlite3_free(pCsr->aPage);
+        pCsr->aPage = 0;
         if( pCsr->bOnePage ) return SQLITE_OK;
         pCsr->iPgno++;
       }
+
+      assert( iOff+3+2<=pCsr->nPage );
       pCsr->iCell = pTab->bPtr ? -2 : 0;
       pCsr->nCell = get_uint16(&pCsr->aPage[iOff+3]);
     }
@@ -13261,8 +13265,7 @@ static int dbdataGetEncoding(DbdataCursor *pCsr){
   int nPg1 = 0;
   u8 *aPg1 = 0;
   rc = dbdataLoadPage(pCsr, 1, &aPg1, &nPg1);
-  assert( rc!=SQLITE_OK || nPg1==0 || nPg1>=512 );
-  if( rc==SQLITE_OK && nPg1>0 ){
+  if( rc==SQLITE_OK && nPg1>=(56+4) ){
     pCsr->enc = get_uint32(&aPg1[56]);
   }
   sqlite3_free(aPg1);
@@ -17921,6 +17924,7 @@ static char *shell_error_context(const char *zSql, sqlite3 *db){
   if( db==0
    || zSql==0
    || (iOffset = sqlite3_error_offset(db))<0
+   || iOffset>=strlen(zSql)
   ){
     return sqlite3_mprintf("");
   }

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.41.1"
-#define SQLITE_VERSION_NUMBER 3041001
-#define SQLITE_SOURCE_ID      "2023-03-10 12:13:52 20399f3eda5ec249d147ba9e48da6e87f969d7966a9a896764ca437ff7e737ff"
+#define SQLITE_VERSION        "3.41.2"
+#define SQLITE_VERSION_NUMBER 3041002
+#define SQLITE_SOURCE_ID      "2023-03-22 11:56:21 0d1fc92f94cb6b76bffe3ec34d69cffde2924203304e8ffc4155597af0c191da"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## SQLite Release 3.41.2 On 2023-03-22

1. Multiple fixes for reads past the end of memory buffers (NB: reads not writes) in the following circumstances:
    1. When processing a corrupt database file using the non-standard SQLITE_ENABLE_STAT4 compile-time option.
    2. In the CLI when the sqlite3_error_offset() routine returns an out-of-range value (see also the fix to sqlite3_error_offset() below).
    3. In the recovery extension.
    4. In FTS3 when processing a corrupt database file.
2. Fix the sqlite3_error_offset() so that it does not return out-of-range values when reporting errors associated with generated columns.
3. Multiple fixes in the query optimizer for problems that cause incorrect results for bizarre, fuzzer-generated queries.
4. Increase the size of the reference counter in the page cache object to 64 bits to ensure that the counter never overflows.
5. Fix a performance regression caused by a bug fix in patch release 3.41.1.
6. Fix a few incorrect assert() statements.