### PR TITLE
SQLite Release 3.43.1

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
+## SQLite Release 3.43.1 On 2023-09-11
+
+1. Fix a regression in the way that the sum(), avg(), and total() aggregate functions handle infinities.
+2. Fix a bug in the json_array_length() function that occurs when the argument comes directly from json_remove().
+3. Fix the omit-unused-subquery-columns optimization (introduced in in version 3.42.0) so that it works correctly if the subquery is a compound where one arm is DISTINCT and the other is not.
+4. Other minor fixes.
+
 ## SQLite Release 3.43.0 On 2023-08-24
+
 1. Add support for Contentless-Delete FTS5 Indexes. This is a variety of FTS5 full-text search index that omits storing the content that is being indexed while also allowing records to be deleted.
 2. Enhancements to the date and time functions:
     1. Added new time shift modifiers of the form ±YYYY-MM-DD HH:MM:SS.SSS.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2023/sqlite-amalgamation-3430000.zip
+Download: https://sqlite.org/2023/sqlite-amalgamation-3430100.zip
 
 ```
-Archive:  sqlite-amalgamation-3430000.zip
+Archive:  sqlite-amalgamation-3430100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2023-08-24 15:59 00000000  sqlite-amalgamation-3430000/
- 8847124  Defl:N  2278980  74% 2023-08-24 15:59 c4426139  sqlite-amalgamation-3430000/sqlite3.c
-  883610  Defl:N   227265  74% 2023-08-24 15:59 2b45c457  sqlite-amalgamation-3430000/shell.c
-  628463  Defl:N   162763  74% 2023-08-24 15:59 6cb093c9  sqlite-amalgamation-3430000/sqlite3.h
-   37831  Defl:N     6575  83% 2023-08-24 15:59 95f66693  sqlite-amalgamation-3430000/sqlite3ext.h
+       0  Stored        0   0% 2023-09-11 15:43 00000000  sqlite-amalgamation-3430100/
+ 8847384  Defl:N  2279034  74% 2023-09-11 15:43 ff899276  sqlite-amalgamation-3430100/sqlite3.c
+  883610  Defl:N   227265  74% 2023-09-11 15:43 2b45c457  sqlite-amalgamation-3430100/shell.c
+  628463  Defl:N   162757  74% 2023-09-11 15:43 0bb049da  sqlite-amalgamation-3430100/sqlite3.h
+   37831  Defl:N     6575  83% 2023-09-11 15:43 95f66693  sqlite-amalgamation-3430100/sqlite3ext.h
 --------          -------  ---                            -------
-10397028          2675583  74%                            5 files
+10397288          2675631  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.43.0"
-#define SQLITE_VERSION_NUMBER 3043000
-#define SQLITE_SOURCE_ID      "2023-08-24 12:36:59 0f80b798b3f4b81a7bb4233c58294edd0f1156f36b6ecf5ab8e83631d468778c"
+#define SQLITE_VERSION        "3.43.1"
+#define SQLITE_VERSION_NUMBER 3043001
+#define SQLITE_SOURCE_ID      "2023-09-11 12:01:27 2d3a40c05c49e1a49264912b1a05bc2143ac0e7c3df588276ce80a4cbc9bd1b0"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
# SQLite Release 3.43.1 On 2023-09-11

1. Fix a regression in the way that the sum(), avg(), and total() aggregate functions handle infinities.
2. Fix a bug in the json_array_length() function that occurs when the argument comes directly from json_remove().
3. Fix the omit-unused-subquery-columns optimization (introduced in in version 3.42.0) so that it works correctly if the subquery is a compound where one arm is DISTINCT and the other is not.
4. Other minor fixes.
