### PR TITLE
Release/v3.43.2

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## SQLite Release 3.43.2 On 2023-10-10
+
+1. Fix a couple of obscure UAF errors and an obscure memory leak.
+2. Omit the use of the sprintf() function from the standard library in the CLI, as this now generates warnings on some platforms.
+3. Avoid conversion of a double into unsigned long long integer, as some platforms do not do such conversions correctly.
+
 ## SQLite Release 3.43.1 On 2023-09-11
 
 1. Fix a regression in the way that the sum(), avg(), and total() aggregate functions handle infinities.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2023/sqlite-amalgamation-3430100.zip
+Download: https://sqlite.org/2023/sqlite-amalgamation-3430200.zip
 
 ```
-Archive:  sqlite-amalgamation-3430100.zip
+Archive:  sqlite-amalgamation-3430200.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2023-09-11 15:43 00000000  sqlite-amalgamation-3430100/
- 8847384  Defl:N  2279034  74% 2023-09-11 15:43 ff899276  sqlite-amalgamation-3430100/sqlite3.c
-  883610  Defl:N   227265  74% 2023-09-11 15:43 2b45c457  sqlite-amalgamation-3430100/shell.c
-  628463  Defl:N   162757  74% 2023-09-11 15:43 0bb049da  sqlite-amalgamation-3430100/sqlite3.h
-   37831  Defl:N     6575  83% 2023-09-11 15:43 95f66693  sqlite-amalgamation-3430100/sqlite3ext.h
+       0  Stored        0   0% 2023-10-10 17:08 00000000  sqlite-amalgamation-3430200/
+ 8847710  Defl:N  2279077  74% 2023-10-10 17:08 a43fb182  sqlite-amalgamation-3430200/sqlite3.c
+  883624  Defl:N   227272  74% 2023-10-10 17:08 710afc3d  sqlite-amalgamation-3430200/shell.c
+  628463  Defl:N   162759  74% 2023-10-10 17:08 ae42249b  sqlite-amalgamation-3430200/sqlite3.h
+   37831  Defl:N     6575  83% 2023-10-10 17:08 95f66693  sqlite-amalgamation-3430200/sqlite3ext.h
 --------          -------  ---                            -------
-10397288          2675631  74%                            5 files
+10397628          2675683  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -1260,7 +1260,7 @@ static void shellDtostr(
   char z[400];
   if( n<1 ) n = 1;
   if( n>350 ) n = 350;
-  sprintf(z, "%#+.*e", n, r);
+  snprintf(z, sizeof(z)-1, "%#+.*e", n, r);
   sqlite3_result_text(pCtx, z, -1, SQLITE_TRANSIENT);
 }
 

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.43.1"
-#define SQLITE_VERSION_NUMBER 3043001
-#define SQLITE_SOURCE_ID      "2023-09-11 12:01:27 2d3a40c05c49e1a49264912b1a05bc2143ac0e7c3df588276ce80a4cbc9bd1b0"
+#define SQLITE_VERSION        "3.43.2"
+#define SQLITE_VERSION_NUMBER 3043002
+#define SQLITE_SOURCE_ID      "2023-10-10 12:14:04 4310099cce5a487035fa535dd3002c59ac7f1d1bec68d7cf317fd3e769484790"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## SQLite Release 3.43.2 On 2023-10-10

1. Fix a couple of obscure UAF errors and an obscure memory leak.
2. Omit the use of the sprintf() function from the standard library in the CLI, as this now generates warnings on some platforms.
3. Avoid conversion of a double into unsigned long long integer, as some platforms do not do such conversions correctly.
