### PR TITLE
Release/v3.44.2

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## SQLite Release 3.44.2 On 2023-11-24
+
+1. Fix a mistake in the CLI that was introduced by the fix (item 15 above) in 3.44.1.
+2. Fix a problem in FTS5 that was discovered during internal fuzz testing only minutes after the 3.44.1 release was tagged.
+3. Fix incomplete assert() statements that the fuzzer discovered the day after the previous release.
+4. Fix a couple of harmless compiler warnings that appeared in debug builds with GCC 16.
+
 ## SQLite Release 3.44.1 On 2023-11-22
 
 1. Change the CLI so that it uses UTF-16 for console I/O on Windows. This enables proper display of unicode text on old Windows7 machines.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2023/sqlite-amalgamation-3440100.zip
+Download: https://sqlite.org/2023/sqlite-amalgamation-3440200.zip
 
 ```
-Archive:  sqlite-amalgamation-3440100.zip
+Archive:  sqlite-amalgamation-3440200.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2023-11-22 15:53 00000000  sqlite-amalgamation-3440100/
- 8916289  Defl:N  2295968  74% 2023-11-22 15:53 4f3a4c17  sqlite-amalgamation-3440100/sqlite3.c
-  907040  Defl:N   234557  74% 2023-11-22 15:53 7d403735  sqlite-amalgamation-3440100/shell.c
-  637671  Defl:N   165174  74% 2023-11-22 15:53 c7da43f5  sqlite-amalgamation-3440100/sqlite3.h
-   38149  Defl:N     6615  83% 2023-11-22 15:53 c5ea7fc8  sqlite-amalgamation-3440100/sqlite3ext.h
+       0  Stored        0   0% 2023-11-24 14:33 00000000  sqlite-amalgamation-3440200/
+ 8916712  Defl:N  2296096  74% 2023-11-24 14:33 1630d1c7  sqlite-amalgamation-3440200/sqlite3.c
+  907053  Defl:N   234559  74% 2023-11-24 14:33 3d296679  sqlite-amalgamation-3440200/shell.c
+  637671  Defl:N   165172  74% 2023-11-24 14:33 ba6cc53c  sqlite-amalgamation-3440200/sqlite3.h
+   38149  Defl:N     6615  83% 2023-11-24 14:33 c5ea7fc8  sqlite-amalgamation-3440200/sqlite3ext.h
 --------          -------  ---                            -------
-10499149          2702314  74%                            5 files
+10499585          2702442  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -894,8 +894,8 @@ static PerStreamTags * getDesignatedEmitStream(FILE *pf, unsigned chix,
 ** chix equals 1 or 2, or for an arbitrary stream when chix == 0.
 ** In either case, ppst references a caller-owned PerStreamTags
 ** struct which may be filled in if none of the known writable
-** streams is being held by consoleInfo. The ppf parameter is an
-** output when chix!=0 and an input when chix==0.
+** streams is being held by consoleInfo. The ppf parameter is a
+** byref output when chix!=0 and a byref input when chix==0.
  */
 static PerStreamTags *
 getEmitStreamInfo(unsigned chix, PerStreamTags *ppst,
@@ -908,7 +908,7 @@ getEmitStreamInfo(unsigned chix, PerStreamTags *ppst,
       ppstTry = &consoleInfo.pstSetup[chix];
       pfEmit = ppst->pf;
     }else pfEmit = ppstTry->pf;
-    if( !isValidStreamInfo(ppst) ){
+    if( !isValidStreamInfo(ppstTry) ){
       pfEmit = (chix > 1)? stderr : stdout;
       ppstTry = ppst;
       streamOfConsole(pfEmit, ppstTry);

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.44.1"
-#define SQLITE_VERSION_NUMBER 3044001
-#define SQLITE_SOURCE_ID      "2023-11-22 14:18:12 d295f48e8f367b066b881780c98bdf980a1d550397d5ba0b0e49842c95b3e8b4"
+#define SQLITE_VERSION        "3.44.2"
+#define SQLITE_VERSION_NUMBER 3044002
+#define SQLITE_SOURCE_ID      "2023-11-24 11:41:44 ebead0e7230cd33bcec9f95d2183069565b9e709bf745c9b5db65cc0cbf92c0f"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## SQLite Release 3.44.2 On 2023-11-24

1. Fix a mistake in the CLI that was introduced by the fix (item 15 above) in 3.44.1.
2. Fix a problem in FTS5 that was discovered during internal fuzz testing only minutes after the 3.44.1 release was tagged.
3. Fix incomplete assert() statements that the fuzzer discovered the day after the previous release.
4. Fix a couple of harmless compiler warnings that appeared in debug builds with GCC 16.