### PR TITLE
Release/v3.45.1

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## QLite Release 3.45.0 On 2024-01-15
+## SQLite Release 3.45.1 On 2024-01-30
+
+1. Restore the JSON BLOB input bug, and promise to support the anomaly in subsequent releases, for backward compatibility.
+2. Fix the PRAGMA integrity_check command so that it works on read-only databases that contain FTS3 and FTS5 tables. This resolves an issue introduced in version 3.44.0 but was undiscovered until after the 3.45.0 release.
+3. Fix issues associated with processing corrupt JSONB inputs:
+    1. Prevent exponential runtime when converting a corrupt JSONB into text.
+    2. Fix a possible read of one byte past the end of the JSONB blob when converting a corrupt JSONB into text.
+    3. Enhanced testing using jfuzz to prevent any future JSONB problems such as the above.
+4. Fix a long-standing bug in which a read of a few bytes past the end of a memory-mapped segment might occur when accessing a craftily corrupted database using memory-mapped database.
+5. Fix a long-standing bug in which a NULL pointer dereference might occur in the bytecode engine due to incorrect bytecode being generated for a class of SQL statements that are deliberately designed to stress the query planner but which are otherwise pointless.
+
+## SQLite Release 3.45.0 On 2024-01-15
 
 1. Added the SQLITE_RESULT_SUBTYPE property for application-defined SQL functions. All application defined SQL functions that invokes sqlite3_result_subtype() must be registered with this new property. Failure to do so might cause the call to sqlite3_result_subtype() to behave as a no-op. Compile with -DSQLITE_STRICT_SUBTYPE=1 to cause an SQL error to be raised if a function that is not SQLITE_RESULT_SUBTYPE tries invokes sqlite3_result_subtype(). The use of -DSQLITE_STRICT_SUBTYPE=1 is a recommended compile-time option for every application that makes use of subtypes.
 2. Enhancements to the JSON SQL functions:

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2024/sqlite-amalgamation-3450000.zip
+Download: https://sqlite.org/2024/sqlite-amalgamation-3450100.zip
 
 ```
-Archive:  sqlite-amalgamation-3450000.zip
+Archive:  sqlite-amalgamation-3450100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2024-01-15 18:26 00000000  sqlite-amalgamation-3450000/
- 9015946  Defl:N  2320677  74% 2024-01-15 18:26 1fad4631  sqlite-amalgamation-3450000/sqlite3.c
-  910851  Defl:N   235735  74% 2024-01-15 18:26 e72dd380  sqlite-amalgamation-3450000/shell.c
-  640658  Defl:N   165815  74% 2024-01-15 18:26 b9a43d29  sqlite-amalgamation-3450000/sqlite3.h
-   38149  Defl:N     6615  83% 2024-01-15 18:26 c5ea7fc8  sqlite-amalgamation-3450000/sqlite3ext.h
+       0  Stored        0   0% 2024-01-30 17:24 00000000  sqlite-amalgamation-3450100/
+ 9018109  Defl:N  2321520  74% 2024-01-30 17:24 4629c591  sqlite-amalgamation-3450100/sqlite3.c
+  910851  Defl:N   235735  74% 2024-01-30 17:24 e72dd380  sqlite-amalgamation-3450100/shell.c
+  640658  Defl:N   165811  74% 2024-01-30 17:24 0e669db2  sqlite-amalgamation-3450100/sqlite3.h
+   38149  Defl:N     6615  83% 2024-01-30 17:24 c5ea7fc8  sqlite-amalgamation-3450100/sqlite3ext.h
 --------          -------  ---                            -------
-10605604          2728842  74%                            5 files
+10607767          2729681  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.45.0"
-#define SQLITE_VERSION_NUMBER 3045000
-#define SQLITE_SOURCE_ID      "2024-01-15 17:01:13 1066602b2b1976fe58b5150777cced894af17c803e068f5918390d6915b46e1d"
+#define SQLITE_VERSION        "3.45.1"
+#define SQLITE_VERSION_NUMBER 3045001
+#define SQLITE_SOURCE_ID      "2024-01-30 16:01:20 e876e51a0ed5c5b3126f52e532044363a014bc594cfefa87ffb5b82257cc467a"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## SQLite Release 3.45.1 On 2024-01-30

1. Restore the JSON BLOB input bug, and promise to support the anomaly in subsequent releases, for backward compatibility.
2. Fix the PRAGMA integrity_check command so that it works on read-only databases that contain FTS3 and FTS5 tables. This resolves an issue introduced in version 3.44.0 but was undiscovered until after the 3.45.0 release.
3. Fix issues associated with processing corrupt JSONB inputs:
    1. Prevent exponential runtime when converting a corrupt JSONB into text.
    2. Fix a possible read of one byte past the end of the JSONB blob when converting a corrupt JSONB into text.
    3. Enhanced testing using jfuzz to prevent any future JSONB problems such as the above.
4. Fix a long-standing bug in which a read of a few bytes past the end of a memory-mapped segment might occur when accessing a craftily corrupted database using memory-mapped database.
5. Fix a long-standing bug in which a NULL pointer dereference might occur in the bytecode engine due to incorrect bytecode being generated for a class of SQL statements that are deliberately designed to stress the query planner but which are otherwise pointless.