### PR TITLE
Release/v3.46.1

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## SQLite Release 3.46.1 On 2024-08-13
+
+1. Improved robustness while parsing the tokenize= arguments in FTS5. Forum post 171bcc2bcd.
+2. Enhancements to covering index prediction in the query planner. Add early detection of over-prediction of covering indexes so that sqlite3_prepare() will return an error rather than just generate bad bytecode. Forum post e60e4c295d22f8ce.
+3. Do not let the number of terms on a VALUES clause be limited by SQLITE_LIMIT_COMPOUND_SELECT, even if the VALUES clause contains elements that appear to be variables due to double-quoted string literals.
+4. Fix the window function version of group_concat() so that it returns an empty string if it has one or more empty string inputs.
+5. In FTS5 secure-delete mode, fix false-positive integrity-check reports about corrupt indexes.
+6. Syntax errors in ALTER TABLE should always return SQLITE_ERROR. In some cases, they were formerly returning SQLITE_INTERNAL.
+7. JavaScript/WASM:
+    1. Fix a corruption-causing bug in the JavaScript "opfs" VFS.
+    2. Work around a couple of browser-specific OPFS quirks.
+8. Other minor fixes.
+
 ## SQLite Release 3.46.0 On 2024-05-23
 
 1. Enhance PRAGMA optimize in multiple ways, to make it simpler to use:

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2024/sqlite-amalgamation-3460000.zip
+Download: https://sqlite.org/2024/sqlite-amalgamation-3460100.zip
 
 ```
-Archive:  sqlite-amalgamation-3460000.zip
+Archive:  sqlite-amalgamation-3460100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2024-05-23 15:51 00000000  sqlite-amalgamation-3460000/
- 9089040  Defl:N  2341603  74% 2024-05-23 15:51 89547100  sqlite-amalgamation-3460000/sqlite3.c
-  957898  Defl:N   247821  74% 2024-05-23 15:51 291389cf  sqlite-amalgamation-3460000/shell.c
-  644069  Defl:N   166685  74% 2024-05-23 15:51 fc181678  sqlite-amalgamation-3460000/sqlite3.h
-   38149  Defl:N     6615  83% 2024-05-23 15:51 c5ea7fc8  sqlite-amalgamation-3460000/sqlite3ext.h
+       0  Stored        0   0% 2024-08-13 13:02 00000000  sqlite-amalgamation-3460100/
+ 9089564  Defl:N  2341816  74% 2024-08-13 13:02 a9a33f43  sqlite-amalgamation-3460100/sqlite3.c
+  958266  Defl:N   247900  74% 2024-08-13 13:02 2a9cd0d9  sqlite-amalgamation-3460100/shell.c
+  644069  Defl:N   166685  74% 2024-08-13 13:02 e4c8855a  sqlite-amalgamation-3460100/sqlite3.h
+   38149  Defl:N     6615  83% 2024-08-13 13:02 c5ea7fc8  sqlite-amalgamation-3460100/sqlite3ext.h
 --------          -------  ---                            -------
-10729156          2762724  74%                            5 files
+10730048          2763016  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.46.0"
-#define SQLITE_VERSION_NUMBER 3046000
-#define SQLITE_SOURCE_ID      "2024-05-23 13:25:27 96c92aba00c8375bc32fafcdf12429c58bd8aabfcadab6683e35bbb9cdebf19e"
+#define SQLITE_VERSION        "3.46.1"
+#define SQLITE_VERSION_NUMBER 3046001
+#define SQLITE_SOURCE_ID      "2024-08-13 09:16:08 c9c2ab54ba1f5f46360f1b4f35d849cd3f080e6fc2b6c60e91b16c63f69a1e33"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## SQLite Release 3.46.1 On 2024-08-13

1. Improved robustness while parsing the tokenize= arguments in FTS5. Forum post 171bcc2bcd.
2. Enhancements to covering index prediction in the query planner. Add early detection of over-prediction of covering indexes so that sqlite3_prepare() will return an error rather than just generate bad bytecode. Forum post e60e4c295d22f8ce.
3. Do not let the number of terms on a VALUES clause be limited by SQLITE_LIMIT_COMPOUND_SELECT, even if the VALUES clause contains elements that appear to be variables due to double-quoted string literals.
4. Fix the window function version of group_concat() so that it returns an empty string if it has one or more empty string inputs.
5. In FTS5 secure-delete mode, fix false-positive integrity-check reports about corrupt indexes.
6. Syntax errors in ALTER TABLE should always return SQLITE_ERROR. In some cases, they were formerly returning SQLITE_INTERNAL.
7. JavaScript/WASM:
    1. Fix a corruption-causing bug in the JavaScript "opfs" VFS.
    2. Work around a couple of browser-specific OPFS quirks.
8. Other minor fixes.