### PR TITLE
Release/v3.47.1

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## SQLite Release 3.47.1 On 2024-11-25
+
+1. Fix the makefiles so that they once again honored DESTDIR for the "install" target.
+2. Add the SQLITE_IOCAP_SUBPAGE_READ capability to the VFS, to work around issues on some non-standard VFSes caused by making SQLITE_DIRECT_OVERFLOW_READ the default in version 3.45.0.
+3. Fix problems with line endings in the new sqlite3_rsync.exe utility on Windows.
+4. Fix incorrect answers to certain obscure IN queries caused by new query optimizations added in the 3.47.0 release.
+5. Other minor bug fixes.
+
 ## SQLite Release 3.47.0 On 2024-10-21
 
 1. Allow arbitrary expressions in the second argument to the RAISE function.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2024/sqlite-amalgamation-3470000.zip
+Download: https://sqlite.org/2024/sqlite-amalgamation-3470100.zip
 
 ```
-Archive:  sqlite-amalgamation-3470000.zip
+Archive:  sqlite-amalgamation-3470100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2024-10-21 18:48 00000000  sqlite-amalgamation-3470000/
- 9193275  Defl:N  2367775  74% 2024-10-21 18:48 771e2638  sqlite-amalgamation-3470000/sqlite3.c
- 1044127  Defl:N   267023  74% 2024-10-21 18:48 c073b82b  sqlite-amalgamation-3470000/shell.c
-  650689  Defl:N   168160  74% 2024-10-21 18:48 33ab194f  sqlite-amalgamation-3470000/sqlite3.h
-   38149  Defl:N     6615  83% 2024-10-21 18:48 c5ea7fc8  sqlite-amalgamation-3470000/sqlite3ext.h
+       0  Stored        0   0% 2024-11-25 14:55 00000000  sqlite-amalgamation-3470100/
+ 9195316  Defl:N  2368442  74% 2024-11-25 14:55 9447f8cd  sqlite-amalgamation-3470100/sqlite3.c
+ 1044254  Defl:N   267036  74% 2024-11-25 14:55 95272fac  sqlite-amalgamation-3470100/shell.c
+  651186  Defl:N   168326  74% 2024-11-25 14:55 ab5341bd  sqlite-amalgamation-3470100/sqlite3.h
+   38149  Defl:N     6615  83% 2024-11-25 14:55 c5ea7fc8  sqlite-amalgamation-3470100/sqlite3ext.h
 --------          -------  ---                            -------
-10926240          2809573  74%                            5 files
+10928905          2810419  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -460,7 +460,7 @@ char *sqlite3_fgets(char *buf, int sz, FILE *in){
     ** that into UTF-8.  Otherwise, non-ASCII characters all get translated
     ** into '?'.
     */
-    wchar_t *b1 = malloc( sz*sizeof(wchar_t) );
+    wchar_t *b1 = sqlite3_malloc( sz*sizeof(wchar_t) );
     if( b1==0 ) return 0;
     _setmode(_fileno(in), IsConsole(in) ? _O_WTEXT : _O_U8TEXT);
     if( fgetws(b1, sz/4, in)==0 ){
@@ -526,7 +526,7 @@ int sqlite3_fputs(const char *z, FILE *out){
     ** use O_U8TEXT for everything in text mode.
     */
     int sz = (int)strlen(z);
-    wchar_t *b1 = malloc( (sz+1)*sizeof(wchar_t) );
+    wchar_t *b1 = sqlite3_malloc( (sz+1)*sizeof(wchar_t) );
     if( b1==0 ) return 0;
     sz = MultiByteToWideChar(CP_UTF8, 0, z, sz, b1, sz);
     b1[sz] = 0;
@@ -6833,7 +6833,7 @@ static int seriesBestIndex(
       continue;
     }
     if( pConstraint->iColumn<SERIES_COLUMN_START ){
-      if( pConstraint->iColumn==SERIES_COLUMN_VALUE ){
+      if( pConstraint->iColumn==SERIES_COLUMN_VALUE && pConstraint->usable ){
         switch( op ){
           case SQLITE_INDEX_CONSTRAINT_EQ:
           case SQLITE_INDEX_CONSTRAINT_IS: {
@@ -6841,7 +6841,9 @@ static int seriesBestIndex(
             idxNum &= ~0x3300;
             aIdx[5] = i;
             aIdx[6] = -1;
+#ifndef ZERO_ARGUMENT_GENERATE_SERIES
             bStartSeen = 1;
+#endif
             break;
           }
           case SQLITE_INDEX_CONSTRAINT_GE: {
@@ -6849,7 +6851,9 @@ static int seriesBestIndex(
             idxNum |=  0x0100;
             idxNum &= ~0x0200;
             aIdx[5] = i;
+#ifndef ZERO_ARGUMENT_GENERATE_SERIES
             bStartSeen = 1;
+#endif
             break;
           }
           case SQLITE_INDEX_CONSTRAINT_GT: {
@@ -6857,7 +6861,9 @@ static int seriesBestIndex(
             idxNum |=  0x0200;
             idxNum &= ~0x0100;
             aIdx[5] = i;
+#ifndef ZERO_ARGUMENT_GENERATE_SERIES
             bStartSeen = 1;
+#endif
             break;
           }
           case SQLITE_INDEX_CONSTRAINT_LE: {
@@ -14169,7 +14175,7 @@ static int idxCreateVtabSchema(sqlite3expert *p, char **pzErrmsg){
     }else{
       IdxTable *pTab;
       rc = idxGetTableInfo(p->db, zName, &pTab, pzErrmsg);
-      if( rc==SQLITE_OK ){
+      if( rc==SQLITE_OK && ALWAYS(pTab!=0) ){
         int i;
         char *zInner = 0;
         char *zOuter = 0;
@@ -31840,7 +31846,6 @@ static QuickScanState quickscan(char *zLine, QuickScanState qss,
   char cWait = (char)qss; /* intentional narrowing loss */
   if( cWait==0 ){
   PlainScan:
-    assert( cWait==0 );
     while( (cin = *zLine++)!=0 ){
       if( IsSpace(cin) )
         continue;
@@ -31892,7 +31897,6 @@ static QuickScanState quickscan(char *zLine, QuickScanState qss,
           if( *zLine != '/' )
             continue;
           ++zLine;
-          cWait = 0;
           CONTINUE_PROMPT_AWAITC(pst, 0);
           qss = QSS_SETV(qss, 0);
           goto PlainScan;
@@ -31904,7 +31908,6 @@ static QuickScanState quickscan(char *zLine, QuickScanState qss,
           }
           deliberate_fall_through;
         case ']':
-          cWait = 0;
           CONTINUE_PROMPT_AWAITC(pst, 0);
           qss = QSS_SETV(qss, 0);
           goto PlainScan;

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.47.0"
-#define SQLITE_VERSION_NUMBER 3047000
-#define SQLITE_SOURCE_ID      "2024-10-21 16:30:22 03a9703e27c44437c39363d0baf82db4ebc94538a0f28411c85dda156f82636e"
+#define SQLITE_VERSION        "3.47.1"
+#define SQLITE_VERSION_NUMBER 3047001
+#define SQLITE_SOURCE_ID      "2024-11-25 12:07:48 b95d11e958643b969c47a8e5857f3793b9e69700b8f1469371386369a26e577e"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -652,6 +652,13 @@ SQLITE_API int sqlite3_exec(
 ** filesystem supports doing multiple write operations atomically when those
 ** write operations are bracketed by [SQLITE_FCNTL_BEGIN_ATOMIC_WRITE] and
 ** [SQLITE_FCNTL_COMMIT_ATOMIC_WRITE].
+**
+** The SQLITE_IOCAP_SUBPAGE_READ property means that it is ok to read
+** from the database file in amounts that are not a multiple of the
+** page size and that do not begin at a page boundary.  Without this
+** property, SQLite is careful to only do full-page reads and write
+** on aligned pages, with the one exception that it will do a sub-page
+** read of the first page to access the database header.
 */
 #define SQLITE_IOCAP_ATOMIC                 0x00000001
 #define SQLITE_IOCAP_ATOMIC512              0x00000002
@@ -668,6 +675,7 @@ SQLITE_API int sqlite3_exec(
 #define SQLITE_IOCAP_POWERSAFE_OVERWRITE    0x00001000
 #define SQLITE_IOCAP_IMMUTABLE              0x00002000
 #define SQLITE_IOCAP_BATCH_ATOMIC           0x00004000
+#define SQLITE_IOCAP_SUBPAGE_READ           0x00008000
 
 /*
 ** CAPI3REF: File Locking Levels
@@ -814,6 +822,7 @@ struct sqlite3_file {
 ** <li> [SQLITE_IOCAP_POWERSAFE_OVERWRITE]
 ** <li> [SQLITE_IOCAP_IMMUTABLE]
 ** <li> [SQLITE_IOCAP_BATCH_ATOMIC]
+** <li> [SQLITE_IOCAP_SUBPAGE_READ]
 ** </ul>
 **
 ** The SQLITE_IOCAP_ATOMIC property means that all writes of


### PR DESCRIPTION
## SQLite Release 3.47.1 On 2024-11-25

1. Fix the makefiles so that they once again honored DESTDIR for the "install" target.
2. Add the SQLITE_IOCAP_SUBPAGE_READ capability to the VFS, to work around issues on some non-standard VFSes caused by making SQLITE_DIRECT_OVERFLOW_READ the default in version 3.45.0.
3. Fix problems with line endings in the new sqlite3_rsync.exe utility on Windows.
4. Fix incorrect answers to certain obscure IN queries caused by new query optimizations added in the 3.47.0 release.
5. Other minor bug fixes.
