### PR TITLE
Release/v3.47.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,10 @@ unset(_ver_line)
 project(SQLite3
     VERSION ${SQLITE_VERSION}
     DESCRIPTION "SQLite: an embedded SQL database engine"
-    HOMEPAGE_URL https://github.com/algoritnl/sqlite-amalgamation-cmake-buildsystem
+    HOMEPAGE_URL https://github.com/algoritnl/sqlite-amalgamation
     LANGUAGES C)
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
     option(BUILD_SHARED_LIBS "Build using shared libraries." OFF)
     include(CTest)
 endif()
@@ -120,6 +120,9 @@ endif()
 
 # -- Introspection -------------------------------------------------------------
 
+include(CMakePushCheckState)
+cmake_push_check_state(RESET)
+
 if(CMAKE_C_COMPILER_ID MATCHES "(GNU|Clang)")
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
     list(APPEND CMAKE_REQUIRED_LIBRARIES m)
@@ -165,6 +168,8 @@ check_symbol_exists(readlink unistd.h HAVE_READLINK)
 check_symbol_exists(usleep unistd.h HAVE_USLEEP)
 
 check_symbol_exists(utime utime.h HAVE_UTIME)
+
+cmake_pop_check_state()
 
 # -- External Dependencies -----------------------------------------------------
 
@@ -368,7 +373,6 @@ endif()
 # -- Testing -------------------------------------------------------------------
 
 if(BUILD_TESTING AND SQLITE_BUILD_SHELL)
-    enable_testing()
     add_test(NAME SQLiteShellCheckVersion
         COMMAND SQLite::Shell -version)
     set_tests_properties(SQLiteShellCheckVersion PROPERTIES
@@ -387,8 +391,6 @@ if(SQLITE_BUILD_SHELL)
     install(TARGETS Shell
         EXPORT SQLite3Targets)
 endif()
-
-# -- Export --------------------------------------------------------------------
 
 install(EXPORT SQLite3Targets
     NAMESPACE SQLite::
@@ -417,7 +419,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/SQLite3Config.cmake
 
 # -- Packaging -----------------------------------------------------------------
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
     include(InstallRequiredSystemLibraries)
     set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md)
     set(CPACK_RESOURCE_FILE_README ${CMAKE_CURRENT_SOURCE_DIR}/README.md)

--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## SQLite Release 3.47.2 On 2024-12-07
+
+1. Fix a problem in text-to-floating-point conversion for SQLite that can cause values between '1.8446744073709550592eNNN' and '1.8446744073709551609eNNN' for any exponent NNN to be rendered incorrectly. In other words, some numeric text values where the first 16 significant digits are '1844674407370955' might be converted into the wrong floating-point value. See forum thread 569a7209179a7f5e. This problem only arises on x64 and i386 hardware. The problem was introduced in 3.47.0.
+2. Other minor bug fixes.
+
 ## SQLite Release 3.47.1 On 2024-11-25
 
 1. Fix the makefiles so that they once again honored DESTDIR for the "install" target.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2024/sqlite-amalgamation-3470100.zip
+Download: https://sqlite.org/2024/sqlite-amalgamation-3470200.zip
 
 ```
-Archive:  sqlite-amalgamation-3470100.zip
+Archive:  sqlite-amalgamation-3470200.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2024-11-25 14:55 00000000  sqlite-amalgamation-3470100/
- 9195316  Defl:N  2368442  74% 2024-11-25 14:55 9447f8cd  sqlite-amalgamation-3470100/sqlite3.c
- 1044254  Defl:N   267036  74% 2024-11-25 14:55 95272fac  sqlite-amalgamation-3470100/shell.c
-  651186  Defl:N   168326  74% 2024-11-25 14:55 ab5341bd  sqlite-amalgamation-3470100/sqlite3.h
-   38149  Defl:N     6615  83% 2024-11-25 14:55 c5ea7fc8  sqlite-amalgamation-3470100/sqlite3ext.h
+       0  Stored        0   0% 2024-12-07 21:57 00000000  sqlite-amalgamation-3470200/
+ 9195458  Defl:N  2368505  74% 2024-12-07 21:57 d4f520a7  sqlite-amalgamation-3470200/sqlite3.c
+ 1044214  Defl:N   267040  74% 2024-12-07 21:57 24f3c07f  sqlite-amalgamation-3470200/shell.c
+  651186  Defl:N   168328  74% 2024-12-07 21:57 b4edf4b4  sqlite-amalgamation-3470200/sqlite3.h
+   38149  Defl:N     6615  83% 2024-12-07 21:57 c5ea7fc8  sqlite-amalgamation-3470200/sqlite3ext.h
 --------          -------  ---                            -------
-10928905          2810419  74%                            5 files
+10929007          2810488  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -5072,10 +5072,10 @@ int sqlite3_percentile_init(
 ){
   int rc = SQLITE_OK;
   unsigned int i;
-#if defined(SQLITE3_H) || defined(SQLITE_STATIC_PERCENTILE)
-  (void)pApi;      /* Unused parameter */
-#else
+#ifdef SQLITE3EXT_H
   SQLITE_EXTENSION_INIT2(pApi);
+#else
+  (void)pApi;      /* Unused parameter */
 #endif
   (void)pzErrMsg;  /* Unused parameter */
   for(i=0; i<sizeof(aPercentFunc)/sizeof(aPercentFunc[0]); i++){

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.47.1"
-#define SQLITE_VERSION_NUMBER 3047001
-#define SQLITE_SOURCE_ID      "2024-11-25 12:07:48 b95d11e958643b969c47a8e5857f3793b9e69700b8f1469371386369a26e577e"
+#define SQLITE_VERSION        "3.47.2"
+#define SQLITE_VERSION_NUMBER 3047002
+#define SQLITE_SOURCE_ID      "2024-12-07 20:39:59 2aabe05e2e8cae4847a802ee2daddc1d7413d8fc560254d93ee3e72c14685b6c"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## SQLite Release 3.47.2 On 2024-12-07

1. Fix a problem in text-to-floating-point conversion for SQLite that can cause values between '1.8446744073709550592eNNN' and '1.8446744073709551609eNNN' for any exponent NNN to be rendered incorrectly. In other words, some numeric text values where the first 16 significant digits are '1844674407370955' might be converted into the wrong floating-point value. See forum thread 569a7209179a7f5e. This problem only arises on x64 and i386 hardware. The problem was introduced in 3.47.0.
2. Other minor bug fixes.
