### PR TITLE
feat: import release 3.49.1

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## SQLite Release 3.49.1 On 2025-02-18
+
+1. Improve portability of makefiles and configure scripts.
+2. Fix a bug in the concat_ws() function, introduced in version 3.44.0, that could lead to a memory error if the separator string is very large (hundreds of megabytes).
+3. Enhanced the SQLITE_DBCONFIG_LOOKASIDE interface to make it more robust against misuse.
+
 ## SQLite Release 3.49.0 On 2025-02-06
 
 1. Enhancements to the query planner:

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2025/sqlite-amalgamation-3490000.zip
+Download: https://sqlite.org/2025/sqlite-amalgamation-3490100.zip
 
 ```
-Archive:  sqlite-amalgamation-3490000.zip
+Archive:  sqlite-amalgamation-3490100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2025-02-06 14:59 00000000  sqlite-amalgamation-3490000/
- 9232623  Defl:N  2378534  74% 2025-02-06 14:59 192a8c39  sqlite-amalgamation-3490000/sqlite3.c
- 1056211  Defl:N   269962  74% 2025-02-06 14:59 028b8fa6  sqlite-amalgamation-3490000/shell.c
-  658960  Defl:N   170172  74% 2025-02-06 14:59 6d20a34a  sqlite-amalgamation-3490000/sqlite3.h
-   38149  Defl:N     6615  83% 2025-02-06 14:59 c5ea7fc8  sqlite-amalgamation-3490000/sqlite3ext.h
+       0  Stored        0   0% 2025-02-18 15:09 00000000  sqlite-amalgamation-3490100/
+ 9232683  Defl:N  2378552  74% 2025-02-18 15:09 fc400fde  sqlite-amalgamation-3490100/sqlite3.c
+ 1056211  Defl:N   269962  74% 2025-02-18 15:09 028b8fa6  sqlite-amalgamation-3490100/shell.c
+  658960  Defl:N   170174  74% 2025-02-18 15:09 7f75147c  sqlite-amalgamation-3490100/sqlite3.h
+   38149  Defl:N     6615  83% 2025-02-18 15:09 c5ea7fc8  sqlite-amalgamation-3490100/sqlite3ext.h
 --------          -------  ---                            -------
-10985943          2825283  74%                            5 files
+10986003          2825303  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.49.0"
-#define SQLITE_VERSION_NUMBER 3049000
-#define SQLITE_SOURCE_ID      "2025-02-06 11:55:18 4a7dd425dc2a0e5082a9049c9b4a9d4f199a71583d014c24b4cfe276c5a77cde"
+#define SQLITE_VERSION        "3.49.1"
+#define SQLITE_VERSION_NUMBER 3049001
+#define SQLITE_SOURCE_ID      "2025-02-18 13:38:58 873d4e274b4988d260ba8354a9718324a1c26187a4ab4c1cc0227c03d0f10e70"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## SQLite Release 3.49.1 On 2025-02-18

1. Improve portability of makefiles and configure scripts.
2. Fix a bug in the concat_ws() function, introduced in version 3.44.0, that could lead to a memory error if the separator string is very large (hundreds of megabytes).
3. Enhanced the SQLITE_DBCONFIG_LOOKASIDE interface to make it more robust against misuse.
