### PR TITLE
Release/v3.49.2

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## SQLite Release 3.49.2 On 2025-05-07
+
+1. Fix a bug in the NOT NULL optimization of version 3.40.0 (item 3c in the version 3.40.0 change log) that can lead to a memory error if abused.
+2. Fix the count-of-view optimization so that it does not give an incorrect answer for a DISTINCT query.
+3. Fix a possible incorrect answer that can result if a UNIQUE constraint of a table contains the PRIMARY KEY column and that UNIQUE constraint is used by an IN operator.
+4. Fix obscure problems with the generate_series() extension function.
+5. Incremental improvements to the configure/make.
+
 ## SQLite Release 3.49.1 On 2025-02-18
 
 1. Improve portability of makefiles and configure scripts.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2025/sqlite-amalgamation-3490100.zip
+Download: https://sqlite.org/2025/sqlite-amalgamation-3490200.zip
 
 ```
-Archive:  sqlite-amalgamation-3490100.zip
+Archive:  sqlite-amalgamation-3490200.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2025-02-18 15:09 00000000  sqlite-amalgamation-3490100/
- 9232683  Defl:N  2378552  74% 2025-02-18 15:09 fc400fde  sqlite-amalgamation-3490100/sqlite3.c
- 1056211  Defl:N   269962  74% 2025-02-18 15:09 028b8fa6  sqlite-amalgamation-3490100/shell.c
-  658960  Defl:N   170174  74% 2025-02-18 15:09 7f75147c  sqlite-amalgamation-3490100/sqlite3.h
-   38149  Defl:N     6615  83% 2025-02-18 15:09 c5ea7fc8  sqlite-amalgamation-3490100/sqlite3ext.h
+       0  Stored        0   0% 2025-05-07 13:06 00000000  sqlite-amalgamation-3490200/
+ 9233181  Defl:N  2378718  74% 2025-05-07 13:06 04e8893a  sqlite-amalgamation-3490200/sqlite3.c
+ 1056845  Defl:N   270062  74% 2025-05-07 13:06 4279da8b  sqlite-amalgamation-3490200/shell.c
+  658960  Defl:N   170173  74% 2025-05-07 13:06 98e53dd3  sqlite-amalgamation-3490200/sqlite3.h
+   38149  Defl:N     6615  83% 2025-05-07 13:06 c5ea7fc8  sqlite-amalgamation-3490200/sqlite3ext.h
 --------          -------  ---                            -------
-10986003          2825303  74%                            5 files
+10987135          2825568  74%                            5 files
 ```

--- a/source/shell.c
+++ b/source/shell.c
@@ -6267,8 +6267,7 @@ int sqlite3_ieee_init(
 **       step HIDDEN
 **     );
 **
-** The virtual table also has a rowid, logically equivalent to n+1 where
-** "n" is the ascending integer in the aforesaid production definition.
+** The virtual table also has a rowid which is an alias for the value.
 **
 ** Function arguments in queries against this virtual table are translated
 ** into equality constraints against successive hidden columns.  In other
@@ -6323,6 +6322,7 @@ SQLITE_EXTENSION_INIT1
 #include <assert.h>
 #include <string.h>
 #include <limits.h>
+#include <math.h>
 
 #ifndef SQLITE_OMIT_VIRTUALTABLE
 /*
@@ -6483,6 +6483,7 @@ static int seriesConnect(
   int rc;
 
 /* Column numbers */
+#define SERIES_COLUMN_ROWID (-1)
 #define SERIES_COLUMN_VALUE 0
 #define SERIES_COLUMN_START 1
 #define SERIES_COLUMN_STOP  2
@@ -6570,13 +6571,11 @@ static int seriesColumn(
 #endif
 
 /*
-** Return the rowid for the current row, logically equivalent to n+1 where
-** "n" is the ascending integer in the aforesaid production definition.
+** The rowid is the same as the value.
 */
 static int seriesRowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid){
   series_cursor *pCur = (series_cursor*)cur;
-  sqlite3_uint64 n = pCur->ss.uSeqIndexNow;
-  *pRowid = (sqlite3_int64)((n<LARGEST_UINT64)? n+1 : 0);
+  *pRowid = pCur->ss.iValueNow;
   return SQLITE_OK;
 }
 
@@ -6689,25 +6688,52 @@ static int seriesFilter(
     ** constraints on the "value" column.
     */
     if( idxNum & 0x0080 ){
-      iMin = iMax = sqlite3_value_int64(argv[i++]);
+      if( sqlite3_value_numeric_type(argv[i])==SQLITE_FLOAT ){
+        double r = sqlite3_value_double(argv[i++]);
+        if( r==ceil(r) ){
+          iMin = iMax = (sqlite3_int64)r;
+        }else{
+          returnNoRows = 1;
+        }
+      }else{
+        iMin = iMax = sqlite3_value_int64(argv[i++]);
+      }
     }else{
       if( idxNum & 0x0300 ){
-        iMin = sqlite3_value_int64(argv[i++]);
-        if( idxNum & 0x0200 ){
-          if( iMin==LARGEST_INT64 ){
-            returnNoRows = 1;
+        if( sqlite3_value_numeric_type(argv[i])==SQLITE_FLOAT ){
+          double r = sqlite3_value_double(argv[i++]);
+          if( idxNum & 0x0200 && r==ceil(r) ){
+            iMin = (sqlite3_int64)ceil(r+1.0);
           }else{
-            iMin++;
+            iMin = (sqlite3_int64)ceil(r);
+          }
+        }else{
+          iMin = sqlite3_value_int64(argv[i++]);
+          if( idxNum & 0x0200 ){
+            if( iMin==LARGEST_INT64 ){
+              returnNoRows = 1;
+            }else{
+              iMin++;
+            }
           }
         }
       }
       if( idxNum & 0x3000 ){
-        iMax = sqlite3_value_int64(argv[i++]);
-        if( idxNum & 0x2000 ){
-          if( iMax==SMALLEST_INT64 ){
-            returnNoRows = 1;
+        if( sqlite3_value_numeric_type(argv[i])==SQLITE_FLOAT ){
+          double r = sqlite3_value_double(argv[i++]);
+          if( (idxNum & 0x2000)!=0 && r==floor(r) ){
+            iMax = (sqlite3_int64)(r-1.0);
           }else{
-            iMax--;
+            iMax = (sqlite3_int64)floor(r);
+          }
+        }else{
+          iMax = sqlite3_value_int64(argv[i++]);
+          if( idxNum & 0x2000 ){
+            if( iMax==SMALLEST_INT64 ){
+              returnNoRows = 1;
+            }else{
+              iMax--;
+            }
           }
         }
       }
@@ -6726,8 +6752,7 @@ static int seriesFilter(
         pCur->ss.iBase += ((d+szStep-1)/szStep)*szStep;
       }
       if( pCur->ss.iTerm>iMax ){
-        sqlite3_uint64 d = pCur->ss.iTerm - iMax;
-        pCur->ss.iTerm -= ((d+szStep-1)/szStep)*szStep;
+        pCur->ss.iTerm = iMax;
       }
     }else{
       sqlite3_int64 szStep = -pCur->ss.iStep;
@@ -6737,8 +6762,7 @@ static int seriesFilter(
         pCur->ss.iBase -= ((d+szStep-1)/szStep)*szStep;
       }
       if( pCur->ss.iTerm<iMin ){
-        sqlite3_uint64 d = iMin - pCur->ss.iTerm;
-        pCur->ss.iTerm += ((d+szStep-1)/szStep)*szStep;
+        pCur->ss.iTerm = iMin;
       }
     }
   }
@@ -6866,7 +6890,10 @@ static int seriesBestIndex(
       continue;
     }
     if( pConstraint->iColumn<SERIES_COLUMN_START ){
-      if( pConstraint->iColumn==SERIES_COLUMN_VALUE && pConstraint->usable ){
+      if( (pConstraint->iColumn==SERIES_COLUMN_VALUE ||
+           pConstraint->iColumn==SERIES_COLUMN_ROWID)
+       && pConstraint->usable
+      ){
         switch( op ){
           case SQLITE_INDEX_CONSTRAINT_EQ:
           case SQLITE_INDEX_CONSTRAINT_IS: {

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.49.1"
-#define SQLITE_VERSION_NUMBER 3049001
-#define SQLITE_SOURCE_ID      "2025-02-18 13:38:58 873d4e274b4988d260ba8354a9718324a1c26187a4ab4c1cc0227c03d0f10e70"
+#define SQLITE_VERSION        "3.49.2"
+#define SQLITE_VERSION_NUMBER 3049002
+#define SQLITE_SOURCE_ID      "2025-05-07 10:39:52 17144570b0d96ae63cd6f3edca39e27ebd74925252bbaf6723bcb2f6b4861fb1"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## SQLite Release 3.49.2 On 2025-05-07

1. Fix a bug in the NOT NULL optimization of version 3.40.0 (item 3c in the version 3.40.0 change log) that can lead to a memory error if abused.
2. Fix the count-of-view optimization so that it does not give an incorrect answer for a DISTINCT query.
3. Fix a possible incorrect answer that can result if a UNIQUE constraint of a table contains the PRIMARY KEY column and that UNIQUE constraint is used by an IN operator.
4. Fix obscure problems with the generate_series() extension function.
5. Incremental improvements to the configure/make.