### PR TITLE
SQLite Release 3.50.1

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## SQLite Release 3.50.1 On 2025-06-06
+
+1. Fix a long-standing bug in jsonb_set() and similar that was exposed by new optimizations added in version 3.50.0.
+2. Fix an apparently harmless ASAN warning that can occur on builds that use -DSQLITE_DEFAULT_MEMSTATUS=0.
+3. Fix an off-by-one bug in sqlite3_rsync that can result in the last page not being transferred for the replicate database.
+4. Query planner optimization: Allow the right-hand side of a LEFT JOIN to be flattened even if it is a virtual table.
+5. Fix sqlite3_setlk_timeout() to use a blocking lock when opening a snapshot transaction and when blocked by another process running recovery.
+6. Other minor fixes that were reported after the 3.50.0 release.
+
 ## SQLite Release 3.50.0 On 2025-05-29
 
 1. Add the sqlite3_setlk_timeout() interface which sets a separate timeout, distinct from the sqlite3_busy_timeout(), for blocking locks on builds that support blocking locks.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2025/sqlite-amalgamation-3500000.zip
+Download: https://sqlite.org/2025/sqlite-amalgamation-3500100.zip
 
 ```
-Archive:  sqlite-amalgamation-3500000.zip
+Archive:  sqlite-amalgamation-3500100.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2025-05-29 16:35 00000000  sqlite-amalgamation-3500000/
- 9278257  Defl:N  2392688  74% 2025-05-29 16:35 aeae5f82  sqlite-amalgamation-3500000/sqlite3.c
- 1066637  Defl:N   273039  74% 2025-05-29 16:35 dca41d4c  sqlite-amalgamation-3500000/shell.c
-  661913  Defl:N   171091  74% 2025-05-29 16:35 99195703  sqlite-amalgamation-3500000/sqlite3.h
-   38321  Defl:N     6640  83% 2025-05-29 16:35 50ad28b2  sqlite-amalgamation-3500000/sqlite3ext.h
+       0  Stored        0   0% 2025-06-06 17:14 00000000  sqlite-amalgamation-3500100/
+ 9279422  Defl:N  2393025  74% 2025-06-06 17:14 4a67418c  sqlite-amalgamation-3500100/sqlite3.c
+ 1066637  Defl:N   273039  74% 2025-06-06 17:14 dca41d4c  sqlite-amalgamation-3500100/shell.c
+  661913  Defl:N   171087  74% 2025-06-06 17:14 7f74fa5a  sqlite-amalgamation-3500100/sqlite3.h
+   38321  Defl:N     6640  83% 2025-06-06 17:14 50ad28b2  sqlite-amalgamation-3500100/sqlite3ext.h
 --------          -------  ---                            -------
-11045128          2843458  74%                            5 files
+11046293          2843791  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.50.0"
-#define SQLITE_VERSION_NUMBER 3050000
-#define SQLITE_SOURCE_ID      "2025-05-29 14:26:00 dfc790f998f450d9c35e3ba1c8c89c17466cb559f87b0239e4aab9d34e28f742"
+#define SQLITE_VERSION        "3.50.1"
+#define SQLITE_VERSION_NUMBER 3050001
+#define SQLITE_SOURCE_ID      "2025-06-06 14:52:32 b77dc5e0f596d2140d9ac682b2893ff65d3a4140aa86067a3efebe29dc914c95"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## SQLite Release 3.50.1 On 2025-06-06

1. Fix a long-standing bug in jsonb_set() and similar that was exposed by new optimizations added in version 3.50.0.
2. Fix an apparently harmless ASAN warning that can occur on builds that use -DSQLITE_DEFAULT_MEMSTATUS=0.
3. Fix an off-by-one bug in sqlite3_rsync that can result in the last page not being transferred for the replicate database.
4. Query planner optimization: Allow the right-hand side of a LEFT JOIN to be flattened even if it is a virtual table.
5. Fix sqlite3_setlk_timeout() to use a blocking lock when opening a snapshot transaction and when blocked by another process running recovery.
6. Other minor fixes that were reported after the 3.50.0 release.