### PR TITLE
SQLite Release 3.50.4

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## SQLite Release 3.50.4 On 2025-07-30
+
+1. Fix two long-standings cases of the use of uninitialized variables in obscure circumstances.
+
 ## SQLite Release 3.50.3 On 2025-07-17
 
 1. Fix a possible memory error that can occur if a query is made against against FTS5 index that has been deliberately corrupted in a very specific way.

--- a/source/README.md
+++ b/source/README.md
@@ -1,14 +1,14 @@
-Download: https://sqlite.org/2025/sqlite-amalgamation-3500300.zip
+Download: https://sqlite.org/2025/sqlite-amalgamation-3500400.zip
 
 ```
-Archive:  sqlite-amalgamation-3500300.zip
+Archive:  sqlite-amalgamation-3500400.zip
  Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
 --------  ------  ------- ---- ---------- ----- --------  ----
-       0  Stored        0   0% 2025-07-17 15:33 00000000  sqlite-amalgamation-3500300/
- 9281911  Defl:N  2393667  74% 2025-07-17 15:33 1b8efdec  sqlite-amalgamation-3500300/sqlite3.c
- 1066685  Defl:N   273051  74% 2025-07-17 15:33 42b0b5f6  sqlite-amalgamation-3500300/shell.c
-  661968  Defl:N   171059  74% 2025-07-17 15:33 6cf211ed  sqlite-amalgamation-3500300/sqlite3.h
-   38321  Defl:N     6640  83% 2025-07-17 15:33 50ad28b2  sqlite-amalgamation-3500300/sqlite3ext.h
+       0  Stored        0   0% 2025-07-30 21:45 00000000  sqlite-amalgamation-3500400/
+ 9282866  Defl:N  2393950  74% 2025-07-30 21:45 054fd04e  sqlite-amalgamation-3500400/sqlite3.c
+ 1066685  Defl:N   273051  74% 2025-07-30 21:45 42b0b5f6  sqlite-amalgamation-3500400/shell.c
+  661968  Defl:N   171059  74% 2025-07-30 21:45 8f16f2ad  sqlite-amalgamation-3500400/sqlite3.h
+   38321  Defl:N     6640  83% 2025-07-30 21:45 50ad28b2  sqlite-amalgamation-3500400/sqlite3ext.h
 --------          -------  ---                            -------
-11048885          2844417  74%                            5 files
+11049840          2844700  74%                            5 files
 ```

--- a/source/sqlite3.h
+++ b/source/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.50.3"
-#define SQLITE_VERSION_NUMBER 3050003
-#define SQLITE_SOURCE_ID      "2025-07-17 13:25:10 3ce993b8657d6d9deda380a93cdd6404a8c8ba1b185b2bc423703e41ae5f2543"
+#define SQLITE_VERSION        "3.50.4"
+#define SQLITE_VERSION_NUMBER 3050004
+#define SQLITE_SOURCE_ID      "2025-07-30 19:33:53 4d8adfb30e03f9cf27f800a2c1ba3c48fb4ca1b08b0f5ed59a4d5ecbf45e20a3"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## SQLite Release 3.50.3 On 2025-07-17

1. Fix a possible memory error that can occur if a query is made against against FTS5 index that has been deliberately corrupted in a very specific way.
2. Fix the parser so that it ignored SQL comments in all places of a CREATE TRIGGER statement. This resolves a problem that was introduced by the introduction of the SQLITE_DBCONFIG_ENABLE_COMMENTS feature in version 3.49.0.
3. Fix an incorrect answer due to over-optimization of an AND operator. Forum post f4878de3e.
4. Fix minor makefile issues and documentation typos.